### PR TITLE
move strategy deleted event to be with other Carbon events

### DIFF
--- a/fastlane_bot/events/managers/manager.py
+++ b/fastlane_bot/events/managers/manager.py
@@ -42,6 +42,9 @@ class Manager(PoolManager, EventManager, ContractsManager):
         if event["event"] == "PairCreated":
             self.handle_pair_created(event)
             return
+        if event["event"] == "StrategyDeleted":
+            self.handle_strategy_deleted(event)
+            return
 
         addr = self.web3.toChecksumAddress(event["address"])
         ex_name = self.exchange_name_from_event(event)
@@ -63,9 +66,6 @@ class Manager(PoolManager, EventManager, ContractsManager):
             event or {}, pool.get_common_data(event, pool_info) or {}
         )
 
-        if event["event"] == "StrategyDeleted":
-            self.handle_strategy_deleted(event)
-            return
 
         self.update_pool_data(pool_info, data)
 


### PR DESCRIPTION
We need to test if this fixes the issue, however it requires a Strategy Deleted event to check. 