### PR TITLE
Fix for strategy deleted event

### DIFF
--- a/fastlane_bot/events/exchanges/carbon_v1.py
+++ b/fastlane_bot/events/exchanges/carbon_v1.py
@@ -140,7 +140,8 @@ class CarbonV1(Exchange):
         id : str (alias for cid)
             The id of the strategy to delete
         """
-        self.pools.pop(id)
+        if id in self.pools:
+            self.pools.pop(id)
 
     def save_strategy(
         self,


### PR DESCRIPTION
Added a check before trying to delete a strategy that may or may not exist