### PR TITLE
hex string without 0x prefix

### DIFF
--- a/fastlane_bot/events/async_event_update_utils.py
+++ b/fastlane_bot/events/async_event_update_utils.py
@@ -474,7 +474,7 @@ def async_update_pools_from_contracts(mgr: Any, current_block: int, logging_path
     # Initialize web3
     new_pool_data_df["cid"] = [
         cfg.w3.keccak(text=f"{row['descr']}").hex()
-        if row["exchange_name"] != "carbon_v1"
+        if row["exchange_name"] not in mgr.cfg.CARBON_V1_FORKS
         else int(row['cid'])
         for index, row in new_pool_data_df.iterrows()
     ]

--- a/fastlane_bot/events/async_event_update_utils.py
+++ b/fastlane_bot/events/async_event_update_utils.py
@@ -474,6 +474,8 @@ def async_update_pools_from_contracts(mgr: Any, current_block: int, logging_path
     # Initialize web3
     new_pool_data_df["cid"] = [
         cfg.w3.keccak(text=f"{row['descr']}").hex()
+        if row["exchange_name"] != "carbon_v1"
+        else int(row['cid'])
         for index, row in new_pool_data_df.iterrows()
     ]
 


### PR DESCRIPTION
…erly handled

- Carbon cid values are provided by the contract and are int types, whereas all other exchange cid values are generated by hashing the descr (exchange tkn1/tkn2 fee) info.
- This fix ensures that the types and values of carbon cid's are preserved
- This change is also believed to be a fix for the seemingly unrelated `Ox string without prefix` error