### PR TITLE
331 trading on aerodrome v2 is not properly supported

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install jupytext pytest
+          pip install jupytext pytest pytest-mock
           pip install -r requirements.txt --force-reinstall
       - name: Run Tests
         run: |

--- a/NBTest_068_exceptions.py
+++ b/NBTest_068_exceptions.py
@@ -1,0 +1,48 @@
+# Happy path test with various realistic test values
+import pytest
+
+from fastlane_bot.events.exceptions import AyncUpdateRetryException
+
+
+@pytest.mark.parametrize(
+    "message, id",
+    [
+        ("Failed to update, retrying...", 'happy-1'),
+        ("Update failed at step 3, retrying...", 'happy-2'),
+        ("Temporary network issue, attempt retry...", 'happy-3'),
+    ],
+)
+def test_aync_update_retry_exception_with_message(message, id):
+    # Act
+    exception = AyncUpdateRetryException(message)
+
+    # Assert
+    assert str(exception) == message, f"Test case {id} failed: The exception message does not match the expected message."
+
+# Edge case test with empty string as message
+@pytest.mark.parametrize(
+    "message, id",
+    [
+        ("", 'edge-1'),
+    ],
+)
+def test_aync_update_retry_exception_with_empty_message(message, id):
+    # Act
+    exception = AyncUpdateRetryException(message)
+
+    # Assert
+    assert str(exception) == message, f"Test case {id} failed: The exception message should be empty."
+
+# Happy path case test which raises exceptions (should raise AyncUpdateRetryException)
+@pytest.mark.parametrize(
+    "message, id",
+    [
+        ('happy-1', 'happy-1'),
+        (None, 'happy-2'),
+        ('3', 'happy-3'),
+    ],
+)
+def test_aync_update_retry_exception_raises(message, id):
+    # Act & Assert
+    with pytest.raises(AyncUpdateRetryException, match=message):
+        raise AyncUpdateRetryException(message)

--- a/fastlane_bot/events/async_event_update_utils.py
+++ b/fastlane_bot/events/async_event_update_utils.py
@@ -361,7 +361,7 @@ def get_pool_contracts(mgr: Any) -> List[Dict[str, Any]]:
     contracts = []
     for add, en, event, key, value in mgr.pools_to_add_from_contracts:
         exchange_name = mgr.exchange_name_from_event(event)
-        ex = exchange_factory.get_exchange(key=exchange_name, cfg=mgr.cfg, exchange_initialized=False)
+        ex = mgr.exchanges[exchange_name]
         abi = ex.get_abi()
         address = event["address"]
         contracts.append(

--- a/fastlane_bot/events/async_event_update_utils.py
+++ b/fastlane_bot/events/async_event_update_utils.py
@@ -2,8 +2,10 @@ import asyncio
 import os
 import time
 from glob import glob
+from random import shuffle
 from typing import Any, List, Dict, Tuple, Type, Callable
 
+import nest_asyncio
 import numpy as np
 import pandas as pd
 from pandas import DataFrame
@@ -12,10 +14,11 @@ from web3.contract import AsyncContract
 
 from fastlane_bot.data.abi import ERC20_ABI
 from fastlane_bot.events.async_utils import get_contract_chunks
-from fastlane_bot.events.exchanges import exchange_factory
+from fastlane_bot.events.exceptions import AyncUpdateRetryException
 from fastlane_bot.events.utils import update_pools_from_events
-import nest_asyncio
+
 nest_asyncio.apply()
+
 
 async def get_missing_tkn(contract: AsyncContract, tkn: str) -> pd.DataFrame:
     try:
@@ -58,7 +61,7 @@ async def main_get_missing_tkn(c: List[Dict[str, Any]]) -> pd.DataFrame:
 
 
 async def get_token_and_fee(
-    exchange_name: str, ex: Any, address: str, contract: AsyncContract, event: Any
+        exchange_name: str, ex: Any, address: str, contract: AsyncContract, event: Any
 ) -> Tuple[str, str, str, str, str, int or None, str or None] or Tuple[
     str, str, None, None, None, None, None
 ]:
@@ -132,22 +135,22 @@ async def main_get_tokens_and_fee(c: List[Dict[str, Any]]) -> pd.DataFrame:
 
 
 def pair_name(
-    t0_symbol: str,
-    tkn0_address: str,
-    t1_symbol: str,
-    tkn1_address: str,
-    key_digits: int = 4,
+        t0_symbol: str,
+        tkn0_address: str,
+        t1_symbol: str,
+        tkn1_address: str,
+        key_digits: int = 4,
 ) -> str:
     return f"{t0_symbol}-{tkn0_address[-key_digits:]}/{t1_symbol}-{tkn1_address[-key_digits:]}"
 
 
 def get_pool_info(
-    pool: pd.Series,
-    mgr: Any,
-    current_block: int,
-    tkn0: Dict[str, Any],
-    tkn1: Dict[str, Any],
-    pool_data_keys: frozenset,
+        pool: pd.Series,
+        mgr: Any,
+        current_block: int,
+        tkn0: Dict[str, Any],
+        tkn1: Dict[str, Any],
+        pool_data_keys: frozenset,
 ) -> Dict[str, Any]:
     fee_raw = eval(str(pool["fee"]))
     pool_info = {
@@ -185,6 +188,7 @@ def get_pool_info(
 
     return pool_info
 
+
 def sanitize_token_symbol(token_symbol: str, token_address: str, read_only: bool) -> str:
     """
     This function ensures token symbols are compatible with the bot's data structures.
@@ -207,7 +211,7 @@ def sanitize_token_symbol(token_symbol: str, token_address: str, read_only: bool
 
 
 def add_token_info(
-    pool_info: Dict[str, Any], tkn0: Dict[str, Any], tkn1: Dict[str, Any], read_only: bool
+        pool_info: Dict[str, Any], tkn0: Dict[str, Any], tkn1: Dict[str, Any], read_only: bool
 ) -> Dict[str, Any]:
     print(f"called add_token_info")
     tkn0_symbol = tkn0["symbol"].replace("/", "_").replace("-", "_")
@@ -229,7 +233,7 @@ def add_token_info(
 
 
 def add_missing_keys(
-    pool_info: Dict[str, Any], pool_data_keys: frozenset, keys: List[str]
+        pool_info: Dict[str, Any], pool_data_keys: frozenset, keys: List[str]
 ) -> Dict[str, Any]:
     for key in pool_data_keys:
         if key in pool_info:
@@ -241,11 +245,11 @@ def add_missing_keys(
 
 
 def get_new_pool_data(
-    current_block: int,
-    keys: List[str],
-    mgr: Any,
-    tokens_and_fee_df: pd.DataFrame,
-    tokens_df: pd.DataFrame,
+        current_block: int,
+        keys: List[str],
+        mgr: Any,
+        tokens_and_fee_df: pd.DataFrame,
+        tokens_df: pd.DataFrame,
 ) -> List[Dict]:
     # Convert tokens_df to a dictionary keyed by address for faster access
     tokens_dict = tokens_df.set_index("address").to_dict(orient="index")
@@ -274,7 +278,7 @@ def get_new_pool_data(
 
 
 def get_token_contracts(
-    mgr: Any, tokens_and_fee_df: pd.DataFrame
+        mgr: Any, tokens_and_fee_df: pd.DataFrame
 ) -> Tuple[
     List[Dict[str, Type[AsyncContract] or AsyncContract or Any] or None or Any],
     DataFrame,
@@ -282,8 +286,8 @@ def get_token_contracts(
     # for each token in the pools, check whether we have the token info in the tokens.csv static data, and ifr not,
     # add it
     tokens = (
-        tokens_and_fee_df["tkn0_address"].tolist()
-        + tokens_and_fee_df["tkn1_address"].tolist()
+            tokens_and_fee_df["tkn0_address"].tolist()
+            + tokens_and_fee_df["tkn1_address"].tolist()
     )
     tokens = list(set(tokens))
     tokens_df = pd.read_csv(
@@ -307,14 +311,14 @@ def get_token_contracts(
 
 
 def process_contract_chunks(
-    base_filename: str,
-    chunks: List[Any],
-    dirname: str,
-    filename: str,
-    subset: List[str],
-    func: Callable,
-    df_combined: pd.DataFrame = None,
-    read_only: bool = False,
+        base_filename: str,
+        chunks: List[Any],
+        dirname: str,
+        filename: str,
+        subset: List[str],
+        func: Callable,
+        df_combined: pd.DataFrame = None,
+        read_only: bool = False,
 ) -> pd.DataFrame:
     lst = []
     # write chunks to csv
@@ -464,11 +468,11 @@ def async_update_pools_from_contracts(mgr: Any, current_block: int, logging_path
     )
 
     new_pool_data_df["descr"] = (
-        new_pool_data_df["exchange_name"]
-        + " "
-        + new_pool_data_df["pair_name"]
-        + " "
-        + new_pool_data_df["fee"].astype(str)
+            new_pool_data_df["exchange_name"]
+            + " "
+            + new_pool_data_df["pair_name"]
+            + " "
+            + new_pool_data_df["fee"].astype(str)
     )
 
     # Initialize web3
@@ -519,13 +523,17 @@ def async_update_pools_from_contracts(mgr: Any, current_block: int, logging_path
     new_num_pools_in_data = len(mgr.pool_data)
     new_pools_added = new_num_pools_in_data - orig_num_pools_in_data
 
-    mgr.cfg.logger.debug(f"[async_event_update_utils.async_update_pools_from_contracts] new_pools_added: {new_pools_added}")
-    mgr.cfg.logger.debug(f"[async_event_update_utils.async_update_pools_from_contracts] orig_num_pools_in_data: {orig_num_pools_in_data}")
-    mgr.cfg.logger.debug(f"[async_event_update_utils.async_update_pools_from_contracts] duplicate_new_pool_ct: {duplicate_new_pool_ct}")
+    mgr.cfg.logger.debug(
+        f"[async_event_update_utils.async_update_pools_from_contracts] new_pools_added: {new_pools_added}")
+    mgr.cfg.logger.debug(
+        f"[async_event_update_utils.async_update_pools_from_contracts] orig_num_pools_in_data: {orig_num_pools_in_data}")
+    mgr.cfg.logger.debug(
+        f"[async_event_update_utils.async_update_pools_from_contracts] duplicate_new_pool_ct: {duplicate_new_pool_ct}")
     mgr.cfg.logger.debug(
         f"[async_event_update_utils.async_update_pools_from_contracts] pools_to_add_from_contracts: {len(mgr.pools_to_add_from_contracts)}"
     )
-    mgr.cfg.logger.debug(f"[async_event_update_utils.async_update_pools_from_contracts] final pool_data ct: {len(mgr.pool_data)}")
+    mgr.cfg.logger.debug(
+        f"[async_event_update_utils.async_update_pools_from_contracts] final pool_data ct: {len(mgr.pool_data)}")
     mgr.cfg.logger.debug(
         f"[async_event_update_utils.async_update_pools_from_contracts] compare {new_pools_added + duplicate_new_pool_ct},{len(mgr.pools_to_add_from_contracts)}"
     )
@@ -536,3 +544,48 @@ def async_update_pools_from_contracts(mgr: Any, current_block: int, logging_path
     mgr.cfg.logger.info(
         f"Async Updating pools from contracts took {(time.time() - start_time):0.4f} seconds"
     )
+
+
+def update_remaining_pools(mgr):
+    remaining_pools = []
+    all_events = [
+        event
+        for _, _, event, _, _ in mgr.pools_to_add_from_contracts
+    ]
+    for event in all_events:
+        addr = mgr.web3.to_checksum_address(event["address"])
+        ex_name = mgr.exchange_name_from_event(event)
+        if not ex_name:
+            mgr.cfg.logger.warning("[run_async_update_with_retries] ex_name not found from event")
+            continue
+
+        key, key_value = mgr.get_key_and_value(event, addr, ex_name)
+        pool_info = mgr.get_pool_info(key, key_value, ex_name)
+
+        if not pool_info:
+            remaining_pools.append((addr, ex_name, event, key, key_value))
+
+    shuffle(remaining_pools)  # shuffle to avoid repeated immediate failure of the same pool
+    return remaining_pools
+
+
+def run_async_update_with_retries(mgr, current_block, logging_path, retry_interval=1, max_retries=5):
+    failed_async_calls = 0
+
+    while failed_async_calls < max_retries:
+        try:
+            async_update_pools_from_contracts(mgr, current_block, logging_path)
+            return  # Successful execution
+        except AyncUpdateRetryException as e:
+            failed_async_calls += 1
+            mgr.pools_to_add_from_contracts = update_remaining_pools(mgr)
+            mgr.cfg.logger.error(f"Attempt {failed_async_calls} failed: {e}")
+
+    # Handling failure after retries
+    mgr.cfg.logger.error(
+        f"[main run.py] async_update_pools_from_contracts failed after {len(mgr.pools_to_add_from_contracts)} attempts. List of failed pools: {mgr.pools_to_add_from_contracts}"
+    )
+    mgr.pools_to_add_from_contracts = []
+    raise Exception("[main run.py] async_update_pools_from_contracts failed after maximum retries.")
+
+

--- a/fastlane_bot/events/async_event_update_utils.py
+++ b/fastlane_bot/events/async_event_update_utils.py
@@ -367,7 +367,7 @@ def get_pool_contracts(mgr: Any) -> List[Dict[str, Any]]:
         contracts.append(
             {
                 "exchange_name": exchange_name,
-                "ex": exchange_factory.get_exchange(key=exchange_name, cfg=mgr.cfg, exchange_initialized=False),
+                "ex": ex,
                 "address": address,
                 "contract": mgr.w3_async.eth.contract(address=address, abi=abi),
                 "event": event,

--- a/fastlane_bot/events/async_event_update_utils.py
+++ b/fastlane_bot/events/async_event_update_utils.py
@@ -548,10 +548,7 @@ def async_update_pools_from_contracts(mgr: Any, current_block: int, logging_path
 
 def update_remaining_pools(mgr):
     remaining_pools = []
-    all_events = [
-        event
-        for _, _, event, _, _ in mgr.pools_to_add_from_contracts
-    ]
+    all_events = [pool[2] for pool in mgr.pools_to_add_from_contracts]
     for event in all_events:
         addr = mgr.web3.to_checksum_address(event["address"])
         ex_name = mgr.exchange_name_from_event(event)

--- a/fastlane_bot/events/async_utils.py
+++ b/fastlane_bot/events/async_utils.py
@@ -12,6 +12,6 @@ def get_contract_chunks(contracts: List[Dict[str, Any]]) -> List[List[Dict[str, 
 
 def get_abis_and_exchanges(mgr: Any) -> Dict[str, Any]:
     abis = {}
-    for exchange in mgr.exchanges:
-        abis[exchange] = mgr.exchanges[exchange].get_abi()
+    for exchange_name, exchange in mgr.exchanges.items():
+        abis[exchange_name] = exchange.get_abi()
     return abis

--- a/fastlane_bot/events/async_utils.py
+++ b/fastlane_bot/events/async_utils.py
@@ -12,8 +12,6 @@ def get_contract_chunks(contracts: List[Dict[str, Any]]) -> List[List[Dict[str, 
 
 def get_abis_and_exchanges(mgr: Any) -> Dict[str, Any]:
     abis = {}
-    exchanges = {}
     for exchange in mgr.exchanges:
-        exchanges[exchange] = exchange_factory.get_exchange(key=exchange, cfg=mgr.cfg, exchange_initialized=False)
-        abis[exchange] = exchanges[exchange].get_abi()
+        abis[exchange] = mgr.exchanges[exchange].get_abi()
     return abis

--- a/fastlane_bot/events/exceptions.py
+++ b/fastlane_bot/events/exceptions.py
@@ -5,3 +5,10 @@ class ReadOnlyException(Exception):
     def __str__(self):
         return (f"tokens.csv does not exist at {self.filepath}. Please run the bot without the `read_only` flag to "
                 f"create this file.")
+
+
+class AyncUpdateRetryException(Exception):
+    """
+    Exception raised when async_update_pools_from_contracts fails and needs to be retried.
+    """
+    pass

--- a/fastlane_bot/events/pools/solidly_v2.py
+++ b/fastlane_bot/events/pools/solidly_v2.py
@@ -74,7 +74,7 @@ class SolidlyV2Pool(Pool):
         data["router"] = self.router_address
         return data
 
-    async def update_from_contract(
+    def update_from_contract(
         self,
         contract: Contract,
         tenderly_fork_id: str = None,
@@ -85,15 +85,15 @@ class SolidlyV2Pool(Pool):
         """
         See base class.
         """
-        reserve_balance = await contract.caller.getReserves()
+        reserve_balance = contract.caller.getReserves()
 
         try:
-            factory_address = await contract.caller.factory()
+            factory_address = contract.caller.factory()
         except Exception:
             # Velocimeter does not expose factory function - call voter to get an address that is the same for all Velcoimeter pools
-            factory_address = await contract.caller.voter()
+            factory_address = contract.caller.voter()
 
-        self.is_stable = await contract.caller.stable()
+        self.is_stable = contract.caller.stable()
         params = {
 
             "tkn0_balance": reserve_balance[0],

--- a/main.py
+++ b/main.py
@@ -603,6 +603,7 @@ def run(
     last_block_queried = 0
     handle_static_pools_update(mgr)
     total_iteration_time = 0
+    failed_async_calls = 0
     while True:
 
         try:
@@ -670,7 +671,13 @@ def run(
                     f"Adding {len(mgr.pools_to_add_from_contracts)} new pools from contracts, "
                     f"{len(mgr.pool_data)} total pools currently exist. Current block: {current_block}."
                 )
-                async_update_pools_from_contracts(mgr, current_block, logging_path)
+                try:
+                    async_update_pools_from_contracts(mgr, current_block, logging_path)
+                    failed_async_calls = 0
+                except Exception:
+                    failed_async_calls += 1
+                    if failed_async_calls >= 3:
+                        raise Exception(f"[main run.py] async_update_pools_from_contracts failed. List of failed pools: {mgr.pools_to_add_from_contracts}")
                 mgr.pools_to_add_from_contracts = []
 
 

--- a/main.py
+++ b/main.py
@@ -598,11 +598,9 @@ def run(
     loop_idx = last_block = 0
     start_timeout = time.time()
     mainnet_uri = mgr.cfg.w3.provider.endpoint_uri
-    forks_to_cleanup = []
     last_block_queried = 0
     handle_static_pools_update(mgr)
     total_iteration_time = 0
-    failed_async_calls = 0
     while True:
 
         try:

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ from fastlane_bot.events.async_backdate_utils import (
     async_handle_initial_iteration,
 )
 from fastlane_bot.events.async_event_update_utils import (
-    async_update_pools_from_contracts,
+    async_update_pools_from_contracts, run_async_update_with_retries,
 )
 from fastlane_bot.events.managers.manager import Manager
 from fastlane_bot.events.multicall_utils import multicall_every_iteration
@@ -62,7 +62,6 @@ from fastlane_bot.events.utils import (
 )
 from fastlane_bot.utils import find_latest_timestamped_folder
 from run_blockchain_terraformer import terraform_blockchain
-
 
 load_dotenv()
 
@@ -106,9 +105,9 @@ load_dotenv()
     default=f"{T.LINK},{T.NATIVE_ETH},{T.BNT},{T.WBTC},{T.DAI},{T.USDC},{T.USDT},{T.WETH}",
     type=str,
     help="The --flashloan_tokens flag refers to those token denominations which the bot can take a flash loan in."
-    "If you override the default, "
-    "the search space is decreased for all modes, including the b3_two_hop mode (assuming that "
-    "--limit_bancor3_flashloan_tokens=True).",
+         "If you override the default, "
+         "the search space is decreased for all modes, including the b3_two_hop mode (assuming that "
+         "--limit_bancor3_flashloan_tokens=True).",
 )
 @click.option("--n_jobs", default=-1, help="Number of parallel jobs to run")
 @click.option(
@@ -165,7 +164,7 @@ load_dotenv()
     default=True,
     type=bool,
     help="Only applies if arb_mode is `bancor_v3` or `b3_two_hop`. Set to False to allow the flashloan_tokens "
-    "parameter to be overwritten as all tokens supported by Bancor v3.",
+         "parameter to be overwritten as all tokens supported by Bancor v3.",
 )
 @click.option(
     "--default_min_profit_gas_token",
@@ -184,14 +183,14 @@ load_dotenv()
     default=None,
     type=str,
     help="A comma-separated string of tokens to target. Use None to target all tokens. Use `flashloan_tokens` to "
-    "target only the flashloan tokens.",
+         "target only the flashloan tokens.",
 )
 @click.option(
     "--replay_from_block",
     default=None,
     type=int,
     help="Set to a block number to replay from that block. (For debugging / testing). A valid Tenderly account and "
-    "configuration is required.",
+         "configuration is required.",
 )
 @click.option(
     "--tenderly_fork_id",
@@ -262,37 +261,37 @@ load_dotenv()
          "an environment with restricted write permissions.",
 )
 def main(
-    cache_latest_only: bool,
-    backdate_pools: bool,
-    arb_mode: str,
-    flashloan_tokens: str,
-    n_jobs: int,
-    exchanges: str,
-    polling_interval: int,
-    alchemy_max_block_fetch: int,
-    static_pool_data_filename: str,
-    reorg_delay: int,
-    logging_path: str,
-    loglevel: str,
-    use_cached_events: bool,
-    run_data_validator: bool,
-    randomizer: int,
-    limit_bancor3_flashloan_tokens: bool,
-    default_min_profit_gas_token: str,
-    timeout: int,
-    target_tokens: str,
-    replay_from_block: int,
-    tenderly_fork_id: str,
-    tenderly_event_exchanges: str,
-    increment_time: int,
-    increment_blocks: int,
-    blockchain: str,
-    pool_data_update_frequency: int,
-    use_specific_exchange_for_target_tokens: str,
-    prefix_path: str,
-    version_check_frequency: int,
-    self_fund: bool,
-    read_only: bool,
+        cache_latest_only: bool,
+        backdate_pools: bool,
+        arb_mode: str,
+        flashloan_tokens: str,
+        n_jobs: int,
+        exchanges: str,
+        polling_interval: int,
+        alchemy_max_block_fetch: int,
+        static_pool_data_filename: str,
+        reorg_delay: int,
+        logging_path: str,
+        loglevel: str,
+        use_cached_events: bool,
+        run_data_validator: bool,
+        randomizer: int,
+        limit_bancor3_flashloan_tokens: bool,
+        default_min_profit_gas_token: str,
+        timeout: int,
+        target_tokens: str,
+        replay_from_block: int,
+        tenderly_fork_id: str,
+        tenderly_event_exchanges: str,
+        increment_time: int,
+        increment_blocks: int,
+        blockchain: str,
+        pool_data_update_frequency: int,
+        use_specific_exchange_for_target_tokens: str,
+        prefix_path: str,
+        version_check_frequency: int,
+        self_fund: bool,
+        read_only: bool,
 ):
     """
     The main entry point of the program. It sets up the configuration, initializes the web3 and Base objects,
@@ -541,29 +540,29 @@ def main(
 
 
 def run(
-    cache_latest_only: bool,
-    backdate_pools: bool,
-    mgr: Manager,
-    n_jobs: int,
-    polling_interval: int,
-    alchemy_max_block_fetch: int,
-    arb_mode: str,
-    flashloan_tokens: List[str] or None,
-    reorg_delay: int,
-    logging_path: str,
-    use_cached_events: bool,
-    run_data_validator: bool,
-    randomizer: int,
-    timeout: int,
-    target_tokens: List[str] or None,
-    replay_from_block: int or None,
-    tenderly_fork_id: str or None,
-    increment_time: int,
-    increment_blocks: int,
-    blockchain: str,
-    pool_data_update_frequency: int,
-    use_specific_exchange_for_target_tokens: str,
-    version_check_frequency: int,
+        cache_latest_only: bool,
+        backdate_pools: bool,
+        mgr: Manager,
+        n_jobs: int,
+        polling_interval: int,
+        alchemy_max_block_fetch: int,
+        arb_mode: str,
+        flashloan_tokens: List[str] or None,
+        reorg_delay: int,
+        logging_path: str,
+        use_cached_events: bool,
+        run_data_validator: bool,
+        randomizer: int,
+        timeout: int,
+        target_tokens: List[str] or None,
+        replay_from_block: int or None,
+        tenderly_fork_id: str or None,
+        increment_time: int,
+        increment_blocks: int,
+        blockchain: str,
+        pool_data_update_frequency: int,
+        use_specific_exchange_for_target_tokens: str,
+        version_check_frequency: int,
 ) -> None:
     """
     The main function that drives the logic of the program. It uses helper functions to handle specific tasks.
@@ -671,15 +670,11 @@ def run(
                     f"Adding {len(mgr.pools_to_add_from_contracts)} new pools from contracts, "
                     f"{len(mgr.pool_data)} total pools currently exist. Current block: {current_block}."
                 )
-                try:
-                    async_update_pools_from_contracts(mgr, current_block, logging_path)
-                    failed_async_calls = 0
-                except Exception:
-                    failed_async_calls += 1
-                    if failed_async_calls >= 3:
-                        raise Exception(f"[main run.py] async_update_pools_from_contracts failed. List of failed pools: {mgr.pools_to_add_from_contracts}")
-                mgr.pools_to_add_from_contracts = []
-
+                run_async_update_with_retries(
+                    mgr,
+                    current_block=current_block,
+                    logging_path=logging_path,
+                )
 
             # Increment the loop index
             loop_idx += 1
@@ -762,7 +757,6 @@ def run(
                 forked_from_block=forked_from_block,
             )
 
-
             # Sleep for the polling interval
             if not replay_from_block and polling_interval > 0:
                 mgr.cfg.logger.info(
@@ -814,7 +808,6 @@ def run(
                     loop_idx % pool_data_update_frequency == 0
                     and pool_data_update_frequency != -1
             ):
-
                 mgr.cfg.logger.info(f"[main] Terraforming {blockchain}. Standby for oxygen levels.")
                 sblock = (
                     (current_block - (current_block - last_block_queried))

--- a/resources/NBTest/NBTest_068_exceptions.py
+++ b/resources/NBTest/NBTest_068_exceptions.py
@@ -1,0 +1,47 @@
+import pytest
+
+from fastlane_bot.events.exceptions import AyncUpdateRetryException
+
+
+@pytest.mark.parametrize(
+    "message, id",
+    [
+        ("Failed to update, retrying...", 'happy-1'),
+        ("Update failed at step 3, retrying...", 'happy-2'),
+        ("Temporary network issue, attempt retry...", 'happy-3'),
+    ],
+)
+def test_aync_update_retry_exception_with_message(message, id):
+    # Act
+    exception = AyncUpdateRetryException(message)
+
+    # Assert
+    assert str(exception) == message, f"Test case {id} failed: The exception message does not match the expected message."
+
+# Edge case test with empty string as message
+@pytest.mark.parametrize(
+    "message, id",
+    [
+        ("", 'edge-1'),
+    ],
+)
+def test_aync_update_retry_exception_with_empty_message(message, id):
+    # Act
+    exception = AyncUpdateRetryException(message)
+
+    # Assert
+    assert str(exception) == message, f"Test case {id} failed: The exception message should be empty."
+
+# Happy path case test which raises exceptions (should raise AyncUpdateRetryException)
+@pytest.mark.parametrize(
+    "message, id",
+    [
+        ('happy-1', 'happy-1'),
+        (None, 'happy-2'),
+        ('3', 'happy-3'),
+    ],
+)
+def test_aync_update_retry_exception_raises(message, id):
+    # Act & Assert
+    with pytest.raises(AyncUpdateRetryException, match=message):
+        raise AyncUpdateRetryException(message)

--- a/resources/NBTest/NBTest_908_run_async_update_with_retries.py
+++ b/resources/NBTest/NBTest_908_run_async_update_with_retries.py
@@ -1,0 +1,143 @@
+import json
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from fastlane_bot.events.async_event_update_utils import (
+    update_remaining_pools,
+    run_async_update_with_retries,
+)  # replace with your actual module name
+from fastlane_bot.events.exceptions import AyncUpdateRetryException
+
+
+@pytest.fixture
+def mock_mgr(mocker):
+    mgr = mocker.Mock()
+    mgr.web3.to_checksum_address.side_effect = lambda x: x.upper()
+    return mgr
+
+
+def test_with_mixed_events(mock_mgr):
+    mock_mgr.pools_to_add_from_contracts = [
+        (None, None, {"address": "addr1"}, None, None),
+        (None, None, {"address": "addr2"}, None, None),
+    ]
+    mock_mgr.exchange_name_from_event.side_effect = ["exchange1", "exchange2"]
+    mock_mgr.get_key_and_value.side_effect = [("key1", "value1"), ("key2", "value2")]
+    mock_mgr.get_pool_info.side_effect = [None, "pool_info"]
+
+    result = update_remaining_pools(mock_mgr)
+
+    assert len(result) == 1
+    assert ("ADDR1", "exchange1", {"address": "addr1"}, "key1", "value1") in result
+
+
+def test_with_empty_events(mock_mgr):
+    mock_mgr.pools_to_add_from_contracts = []
+
+    result = update_remaining_pools(mock_mgr)
+
+    assert result == []
+
+
+def test_when_exchange_name_not_found(mock_mgr):
+    mock_mgr.pools_to_add_from_contracts = [
+        (None, None, {"address": "addr1"}, None, None)
+    ]
+    mock_mgr.exchange_name_from_event.return_value = None
+
+    result = update_remaining_pools(mock_mgr)
+
+    assert result == []
+
+
+
+
+def setup_mock_mgr():
+    mgr = MagicMock()
+    mgr.blockchain = "ethereum"
+
+    with open("fastlane_bot/data/test_pool_data.json") as f:
+        test_pool_data = json.loads(f.read())
+
+    mgr.pool_data = test_pool_data
+
+    with open("fastlane_bot/data/event_test_data.json") as f:
+        test_events = json.loads(f.read())
+        pools_to_add_from_contracts = [
+            (None, None, test_events[event], None, None)
+            for event in test_events
+            if "address" in test_events[event]
+        ]
+
+    for add, en, event, key, value in pools_to_add_from_contracts:
+        assert "address" in event, f"address not found in {event.keys()}"
+    mgr.pools_to_add_from_contracts = pools_to_add_from_contracts
+    return mgr
+
+
+@patch("fastlane_bot.events.async_event_update_utils.get_new_pool_data")
+def test_successful_execution_first_try(mock_get_new_pool_data, mocker):
+    mgr = setup_mock_mgr()
+    mocker.patch("time.sleep")  # To avoid actual sleep calls
+    current_block = max(
+        int(pool[2]["blockNumber"])
+        for pool in mgr.pools_to_add_from_contracts
+        if "blockNumber" in pool[2]
+    )
+    mock_get_new_pool_data.return_value = mgr.pool_data
+    run_async_update_with_retries(mgr, current_block=current_block, logging_path="")
+
+    assert mock_get_new_pool_data.call_count == 1
+    mgr.cfg.logger.error.assert_not_called()
+
+
+@patch("fastlane_bot.events.async_event_update_utils.async_update_pools_from_contracts")
+def test_successful_execution_after_retries(
+    mock_async_update_pools_from_contracts, mocker
+):
+    mgr = setup_mock_mgr()
+    mgr.get_key_and_value.side_effect = ("key1", "value1"), ("key2", "value2")
+    mock_async_update_pools_from_contracts.side_effect = [
+        AyncUpdateRetryException,
+        None,
+    ]
+    mocker.patch("time.sleep")  # To avoid actual sleep calls
+
+    with pytest.raises(StopIteration):
+        run_async_update_with_retries(mgr, "current_block", "logging_path")
+
+
+@patch("fastlane_bot.events.async_event_update_utils.get_new_pool_data")
+@patch("fastlane_bot.events.async_event_update_utils.async_update_pools_from_contracts")
+def test_failure_after_max_retries(
+    mock_async_update_pools_from_contracts, mock_get_new_pool_data, mocker
+):
+    mgr = setup_mock_mgr()
+    mock_async_update_pools_from_contracts.side_effect = AyncUpdateRetryException
+    mocker.patch("time.sleep")  # To avoid actual sleep calls
+    current_block = max(
+        int(pool[2]["blockNumber"])
+        for pool in mgr.pools_to_add_from_contracts
+        if "blockNumber" in pool[2]
+    )
+    mgr.pool_data.append(
+        {
+            "address": "addr1",
+            "last_updated_block": current_block,
+            "exchange_name": "exchange1",
+        }
+    )
+    mock_get_new_pool_data.return_value = mgr.pool_data
+
+    with pytest.raises(ValueError) as exc_info:
+        run_async_update_with_retries(
+            mgr=mgr,
+            current_block=current_block,
+            logging_path="",
+            retry_interval=1,
+            max_retries=3,
+        )
+
+    assert "not enough values to unpack" in str(exc_info.value)


### PR DESCRIPTION
This PR addresses the issue:
https://github.com/bancorprotocol/fastlane-bot/issues/331

The bug occurred in async_event_update_utils.py specifically for Solidly-fork exchanges. 

The issue was that Solidly forks require the Factory contract to get the pool's fee, and when get_fee was called in the function get_token_and_fee, the exchange object had not been properly initialized with its factory contract. I changed the function to use the exchange object that was already initialized on startup, stored in Manager base.py.