### PR TITLE
337 failed to get tokens and fee for aerodrome v2

### DIFF
--- a/fastlane_bot/bot.py
+++ b/fastlane_bot/bot.py
@@ -637,6 +637,8 @@ class CarbonBot(CarbonBotBase):
                 "tkn1_symbol": current_pool.tkn1_symbol,
                 "tkn0_decimals" : current_pool.tkn0_decimals,
                 "tkn1_decimals": current_pool.tkn1_decimals,
+                "fee": current_pool.fee,
+                "fee_float": current_pool.fee_float
             }
 
             fetched_pool = self.db.mgr.update_from_pool_info(pool_info=pool_info)

--- a/fastlane_bot/bot.py
+++ b/fastlane_bot/bot.py
@@ -637,8 +637,6 @@ class CarbonBot(CarbonBotBase):
                 "tkn1_symbol": current_pool.tkn1_symbol,
                 "tkn0_decimals" : current_pool.tkn0_decimals,
                 "tkn1_decimals": current_pool.tkn1_decimals,
-                "fee": current_pool.fee,
-                "fee_float": current_pool.fee_float
             }
 
             fetched_pool = self.db.mgr.update_from_pool_info(pool_info=pool_info)

--- a/fastlane_bot/events/managers/base.py
+++ b/fastlane_bot/events/managers/base.py
@@ -134,12 +134,11 @@ class BaseManager:
         Handles getting stable & volatile fees for Solidly forks
         """
         exchange_name = exchange.exchange_name
-        self.factory_contracts[exchange_name] = self.web3.eth.contract(
+        self.factory_contracts[exchange_name] = self.w3_async.eth.contract(
             address=self.cfg.FACTORY_MAPPING[exchange_name],
             abi=exchange.get_factory_abi,
         )
         exchange.factory_contract = self.factory_contracts[exchange.exchange_name]
-        #exchange.set_stable_volatile_fee()
 
         return exchange
 


### PR DESCRIPTION
Initialized Solidly Factory contracts using web3 async instead of web3, which was causing Solidly pools to fail to fetch fees in the async function. 

