### PR TITLE
Update txhelpers.py

### DIFF
--- a/fastlane_bot/config/provider.py
+++ b/fastlane_bot/config/provider.py
@@ -120,7 +120,7 @@ class _ConfigProviderAlchemy(ConfigProvider):
             )
 
         if network.GAS_ORACLE_ADDRESS:
-            self.GAS_ORACLE_CONTRACT = self.w3.eth.contract(
+            self.GAS_ORACLE_CONTRACT = self.w3_async.eth.contract(
                 address=network.GAS_ORACLE_ADDRESS,
                 abi=GAS_ORACLE_ABI
             )

--- a/fastlane_bot/helpers/txhelpers.py
+++ b/fastlane_bot/helpers/txhelpers.py
@@ -992,8 +992,11 @@ class TxHelpers:
             The total fee (in gas token) for the l1 gas fee
         """
 
-        tasks = self.ConfigObj.GAS_ORACLE_CONTRACT.caller.basefee(), self.ConfigObj.GAS_ORACLE_CONTRACT.caller.l1FeeOverhead(), self.ConfigObj.GAS_ORACLE_CONTRACT.caller.l1FeeScalar()
-        ethereum_base_fee, fixed_overhead, dynamic_overhead = asyncio.get_event_loop().run_until_complete(asyncio.gather(*tasks))
+        ethereum_base_fee, fixed_overhead, dynamic_overhead = asyncio.get_event_loop().run_until_complete(asyncio.gather(
+            self.ConfigObj.GAS_ORACLE_CONTRACT.caller.basefee(),
+            self.ConfigObj.GAS_ORACLE_CONTRACT.caller.l1FeeOverhead(),
+            self.ConfigObj.GAS_ORACLE_CONTRACT.caller.l1FeeScalar()
+        ))
 
         return self._get_layer_one_gas_fee(signed_transaction=signed_transaction, ethereum_base_fee=ethereum_base_fee, fixed_overhead=fixed_overhead, dynamic_overhead=dynamic_overhead)
 

--- a/fastlane_bot/helpers/txhelpers.py
+++ b/fastlane_bot/helpers/txhelpers.py
@@ -1001,15 +1001,31 @@ class TxHelpers:
         returns: Decimal
             The total fee (in gas token) for the l1 gas fee
         """
-        ethereum_base_fee = await self.ConfigObj.GAS_ORACLE_CONTRACT.caller.basefee()
-        fixed_overhead = await self.ConfigObj.GAS_ORACLE_CONTRACT.caller.l1FeeOverhead()
-        dynamic_overhead = await self.ConfigObj.GAS_ORACLE_CONTRACT.caller.l1FeeScalar()
+        ethereum_base_fee = await self._get_layer_one_gas_price()
+        fixed_overhead = await self._get_layer_one_fee_overhead()
+        dynamic_overhead = await self._get_layer_one_fee_scalar()
         zero_bytes, non_zero_bytes = count_bytes(signed_transaction["rawTransaction"])
         tx_data_gas = zero_bytes * 4 + non_zero_bytes * 16
         tx_total_gas = (tx_data_gas + fixed_overhead) * dynamic_overhead
         l1_data_fee = tx_total_gas * ethereum_base_fee
         ## Dividing by 10 ** 24 because dynamic_overhead is returned in PPM format, and to convert this from WEI format to decimal format (10 ** 18).
         return Decimal(f"{l1_data_fee}e-24")
+
+    async def _get_layer_one_gas_price(self):
+        """
+        Returns the layer one base fee from the Layer 2 gas oracle for Optimism blockchains
+        """
+        return self.ConfigObj.GAS_ORACLE_CONTRACT.caller.basefee()
+    async def _get_layer_one_fee_overhead(self):
+        """
+        Returns the layer one fee overhead from the Layer 2 gas oracle for Optimism blockchains
+        """
+        return self.ConfigObj.GAS_ORACLE_CONTRACT.caller.l1FeeOverhead()
+    async def _get_layer_one_fee_scalar(self):
+        """
+        Returns the layer one fee overhead from the Layer 2 gas oracle for Optimism blockchains
+        """
+        return self.ConfigObj.GAS_ORACLE_CONTRACT.caller.l1FeeScalar()
 
 
 


### PR DESCRIPTION
Issue:
https://github.com/bancorprotocol/fastlane-bot/issues/353

The bot currently throws the following error in the function _get_layer_one_gas_fee:
[bot:run:single] object int can't be used in 'await' expression

Wrapping the contract calls in async functions & awaiting those functions fixes this. 

