### PR TITLE
Fix bug in carbon_v1 pool, function parse event 2

### DIFF
--- a/fastlane_bot/events/pools/carbon_v1.py
+++ b/fastlane_bot/events/pools/carbon_v1.py
@@ -79,7 +79,7 @@ class CarbonV1Pool(Pool):
         """
         order0, order1 = CarbonV1Pool.parse_orders(event_args, event_type)
         data["cid"] = event_args["args"].get("id")
-        if isinstance(order0, list) and isinstance(order1, list):
+        if isinstance(order0, (list, tuple)) and isinstance(order1, (list, tuple)):
             data["y_0"] = order0[0]
             data["z_0"] = order0[1]
             data["A_0"] = order0[2]
@@ -146,10 +146,8 @@ class CarbonV1Pool(Pool):
         fake_event = {
             "args": {
                 "id": strategy[0],
-                "order0": {"y": strategy[3][0][0], "z": strategy[3][0][0], "A": strategy[3][0][2],
-                           "B": strategy[3][0][3]},
-                "order1": {"y": strategy[3][1][0], "z": strategy[3][1][0], "A": strategy[3][1][2],
-                           "B": strategy[3][1][3]},
+                "order0": strategy[3][0],
+                "order1": strategy[3][1],
             }
         }
         params = self.parse_event(self.state, fake_event, "None")

--- a/fastlane_bot/events/pools/carbon_v1.py
+++ b/fastlane_bot/events/pools/carbon_v1.py
@@ -146,8 +146,10 @@ class CarbonV1Pool(Pool):
         fake_event = {
             "args": {
                 "id": strategy[0],
-                "order0": strategy[3][0],
-                "order1": strategy[3][1],
+                "order0": {"y": strategy[3][0][0], "z": strategy[3][0][0], "A": strategy[3][0][2],
+                           "B": strategy[3][0][3]},
+                "order1": {"y": strategy[3][1][0], "z": strategy[3][1][0], "A": strategy[3][1][2],
+                           "B": strategy[3][1][3]},
             }
         }
         params = self.parse_event(self.state, fake_event, "None")

--- a/fastlane_bot/tests/test_033_Pools.py
+++ b/fastlane_bot/tests/test_033_Pools.py
@@ -193,7 +193,42 @@ def test_test_carbon_v1_pool_delete():
     assert (carbon_v1_pool.state['A_1'] == 0)
     
     #
+
+
+def test_create_carbon_fake_event():
+    carbon_v1_pool = CarbonV1Pool()
+    state = {}
+
+    # Example result of calling contract.caller.strategy()
+    strategy = (3743106036130323098097120681749450326077,
+                                '0x617d08085F68070F00fE4945c1e57013f7600b12',
+                                ['0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C',
+                                '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'],
+                                [(0, 0, 67529602313984, 1961605126121825),
+                                (0, 0, 35462792969, 4450510153742)])
     
+    fake_event = {
+            "args": {
+                "id": strategy[0],
+                "order0": {"y": strategy[3][0][0], "z": strategy[3][0][0], "A": strategy[3][0][2],
+                           "B": strategy[3][0][3]},
+                "order1": {"y": strategy[3][1][0], "z": strategy[3][1][0], "A": strategy[3][1][2],
+                           "B": strategy[3][1][3]},
+            }
+        }
+    data = carbon_v1_pool.parse_event(state, fake_event, "None")
+    assert data["cid"] == strategy[0]
+    assert data["y_0"] == strategy[3][0][0]
+    assert data["z_0"] == strategy[3][0][1]
+    assert data["A_0"] == strategy[3][0][2]
+    assert data["B_0"] == strategy[3][0][3]
+    assert data["y_1"] == strategy[3][1][0]
+    assert data["z_1"] == strategy[3][1][1]
+    assert data["A_1"] == strategy[3][1][2]
+    assert data["B_1"] == strategy[3][1][3]
+
+
+
 
 # ------------------------------------------------------------
 # Test      033

--- a/fastlane_bot/tests/test_033_Pools.py
+++ b/fastlane_bot/tests/test_033_Pools.py
@@ -201,21 +201,19 @@ def test_create_carbon_fake_event():
 
     # Example result of calling contract.caller.strategy()
     strategy = (3743106036130323098097120681749450326077,
-                                '0x617d08085F68070F00fE4945c1e57013f7600b12',
-                                ['0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C',
-                                '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'],
-                                [(0, 0, 67529602313984, 1961605126121825),
-                                (0, 0, 35462792969, 4450510153742)])
-    
+                '0x617d08085F68070F00fE4945c1e57013f7600b12',
+                ['0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C',
+                 '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'],
+                [(0, 0, 67529602313984, 1961605126121825),
+                 (0, 0, 35462792969, 4450510153742)])
+
     fake_event = {
-            "args": {
-                "id": strategy[0],
-                "order0": {"y": strategy[3][0][0], "z": strategy[3][0][0], "A": strategy[3][0][2],
-                           "B": strategy[3][0][3]},
-                "order1": {"y": strategy[3][1][0], "z": strategy[3][1][0], "A": strategy[3][1][2],
-                           "B": strategy[3][1][3]},
-            }
+        "args": {
+            "id": strategy[0],
+            "order0": strategy[3][0],
+            "order1": strategy[3][1],
         }
+    }
     data = carbon_v1_pool.parse_event(state, fake_event, "None")
     assert data["cid"] == strategy[0]
     assert data["y_0"] == strategy[3][0][0]
@@ -226,8 +224,6 @@ def test_create_carbon_fake_event():
     assert data["z_1"] == strategy[3][1][1]
     assert data["A_1"] == strategy[3][1][2]
     assert data["B_1"] == strategy[3][1][3]
-
-
 
 
 # ------------------------------------------------------------


### PR DESCRIPTION
Issue: https://github.com/bancorprotocol/fastlane-bot/issues/419

This fixes a bug in `events/pools/carbon_v1.py` function `update_from_contract`.

The function calls the `strategy` function from the Carbon Controller contract.

Example return value:
```
(3743106036130323098097120681749450326077,
 '0x617d08085F68070F00fE4945c1e57013f7600b12',
 ['0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C',
  '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'],
 [(0, 0, 67529602313984, 1961605126121825),
  (0, 0, 35462792969, 4450510153742)])
```

The problem is that the type of each order is `tuple`, and the correct handling for this format in the function `parse_event` is only applied to type `list`.

Therefore this fix adds `tuple` to the `isinstance` check in `parse_event`.

I have included a corresponding test to prove that the updated function works in `test_033_Pools.py`.


