### PR TITLE
Add handling for specific Uni V3 exchanges on Mantle

### DIFF
--- a/fastlane_bot/config/constants.py
+++ b/fastlane_bot/config/constants.py
@@ -11,3 +11,9 @@ FLASHLOAN_FEE_MAP = {
     "fantom": 0.0003,
     "mantle": 0,
 }
+
+ETHEREUM = "ethereum"
+PANCAKESWAP_V3_NAME = "pancakeswap_v3"
+BUTTER_V3_NAME = "butter_v3"
+AGNI_V3_NAME = "agni_v3"
+CLEOPATRA_V3_NAME = "cleopatra_v3"

--- a/fastlane_bot/config/network.py
+++ b/fastlane_bot/config/network.py
@@ -216,9 +216,6 @@ class ConfigNetwork(ConfigBase):
     SOLIDLY_V2_NAME = "solidly_v2"
     VELODROME_V2_NAME = "velodrome_v2"
     SHIBA_V2_NAME = "shiba_v2"
-    BUTTER_V3_NAME = "butter_v3"
-    AGNI_V3_NAME = "agni_v3"
-    CLEOPATRA_V3_NAME = "cleopatra_v3"
     # Base Exchanges
     AERODROME_V2_NAME = "aerodrome_v2"
     AERODROME_V3_NAME = "aerodrome_v3"

--- a/fastlane_bot/config/network.py
+++ b/fastlane_bot/config/network.py
@@ -218,7 +218,7 @@ class ConfigNetwork(ConfigBase):
     SHIBA_V2_NAME = "shiba_v2"
     BUTTER_V3_NAME = "butter_v3"
     AGNI_V3_NAME = "agni_v3"
-
+    CLEOPATRA_V3_NAME = "cleopatra_v3"
     # Base Exchanges
     AERODROME_V2_NAME = "aerodrome_v2"
     AERODROME_V3_NAME = "aerodrome_v3"

--- a/fastlane_bot/config/network.py
+++ b/fastlane_bot/config/network.py
@@ -216,6 +216,8 @@ class ConfigNetwork(ConfigBase):
     SOLIDLY_V2_NAME = "solidly_v2"
     VELODROME_V2_NAME = "velodrome_v2"
     SHIBA_V2_NAME = "shiba_v2"
+    BUTTER_V3_NAME = "butter_v3"
+    AGNI_V3_NAME = "agni_v3"
 
     # Base Exchanges
     AERODROME_V2_NAME = "aerodrome_v2"

--- a/fastlane_bot/helpers/routehandler.py
+++ b/fastlane_bot/helpers/routehandler.py
@@ -320,7 +320,7 @@ class TxRouteHandler(TxRouteHandlerBase):
 
         assert custom_data in "0x", f"[routehandler.py handle_uni_v3_router_switch] Expected the custom data field to contain '0x', but it contained {custom_data}. This function may need to be updated."
         if platform_id == self.ConfigObj.network.EXCHANGE_IDS.get(self.ConfigObj.network.UNISWAP_V3_NAME):
-            if self.ConfigObj.network.NETWORK in "ethereum" or exchange_name in self.ConfigObj.network.PANCAKESWAP_V3_NAME:
+            if self.ConfigObj.network.NETWORK in "ethereum" or exchange_name in [self.ConfigObj.network.PANCAKESWAP_V3_NAME, self.ConfigObj.network.BUTTER_V3_NAME, self.ConfigObj.network.AGNI_V3_NAME]:
                 custom_data = '0x0000000000000000000000000000000000000000000000000000000000000000'
             else:
                 custom_data = '0x0100000000000000000000000000000000000000000000000000000000000000'

--- a/fastlane_bot/helpers/routehandler.py
+++ b/fastlane_bot/helpers/routehandler.py
@@ -320,7 +320,7 @@ class TxRouteHandler(TxRouteHandlerBase):
 
         assert custom_data in "0x", f"[routehandler.py handle_uni_v3_router_switch] Expected the custom data field to contain '0x', but it contained {custom_data}. This function may need to be updated."
         if platform_id == self.ConfigObj.network.EXCHANGE_IDS.get(self.ConfigObj.network.UNISWAP_V3_NAME):
-            if self.ConfigObj.network.NETWORK in "ethereum" or exchange_name in [self.ConfigObj.network.PANCAKESWAP_V3_NAME, self.ConfigObj.network.BUTTER_V3_NAME, self.ConfigObj.network.AGNI_V3_NAME]:
+            if self.ConfigObj.network.NETWORK in "ethereum" or exchange_name in [self.ConfigObj.network.PANCAKESWAP_V3_NAME, self.ConfigObj.network.BUTTER_V3_NAME, self.ConfigObj.network.AGNI_V3_NAME, self.ConfigObj.CLEOPATRA_V3_NAME]:
                 custom_data = '0x0000000000000000000000000000000000000000000000000000000000000000'
             else:
                 custom_data = '0x0100000000000000000000000000000000000000000000000000000000000000'

--- a/fastlane_bot/helpers/routehandler.py
+++ b/fastlane_bot/helpers/routehandler.py
@@ -19,6 +19,7 @@ import pandas as pd
 from .tradeinstruction import TradeInstruction
 from ..events.interface import Pool
 from ..tools.cpc import T
+from fastlane_bot.config.constants import AGNI_V3_NAME, BUTTER_V3_NAME, CLEOPATRA_V3_NAME, PANCAKESWAP_V3_NAME, ETHEREUM
 
 
 @dataclass
@@ -320,7 +321,7 @@ class TxRouteHandler(TxRouteHandlerBase):
 
         assert custom_data in "0x", f"[routehandler.py handle_uni_v3_router_switch] Expected the custom data field to contain '0x', but it contained {custom_data}. This function may need to be updated."
         if platform_id == self.ConfigObj.network.EXCHANGE_IDS.get(self.ConfigObj.network.UNISWAP_V3_NAME):
-            if self.ConfigObj.network.NETWORK in "ethereum" or exchange_name in [self.ConfigObj.network.PANCAKESWAP_V3_NAME, self.ConfigObj.network.BUTTER_V3_NAME, self.ConfigObj.network.AGNI_V3_NAME, self.ConfigObj.CLEOPATRA_V3_NAME]:
+            if self.ConfigObj.network.NETWORK == ETHEREUM or exchange_name in [PANCAKESWAP_V3_NAME, BUTTER_V3_NAME, AGNI_V3_NAME, CLEOPATRA_V3_NAME]:
                 custom_data = '0x0000000000000000000000000000000000000000000000000000000000000000'
             else:
                 custom_data = '0x0100000000000000000000000000000000000000000000000000000000000000'


### PR DESCRIPTION
These exchanges on Mantle use Uniswap V3 Router 01:
-butter_v3
-agni_v3

This change adds the exchanges to the list of exchanges that should use Router 01 in the `handle_custom_data_extras` function in routehandler.py. 