### PR TITLE
Docstrings for files

### DIFF
--- a/fastlane_bot/__init__.py
+++ b/fastlane_bot/__init__.py
@@ -1,3 +1,13 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""
 from .bot import CarbonBot as Bot, __VERSION__, __DATE__
 from .config import Config, ConfigNetwork, ConfigDB, ConfigLogger, ConfigProvider
 

--- a/fastlane_bot/bot.py
+++ b/fastlane_bot/bot.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Main integration point for the bot optimizer and other infrastructure.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 
                       ,(&@(,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
                ,%@@@@@@@@@@,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,.
@@ -39,7 +42,6 @@ Licensed under MIT
     &@@@@@@@@@@@@@@@@@@@@@@@@@@%((((,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
     @@@@@@@@@@@@@@@@@@@@@@@@@@@@&(((,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
     (@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@((,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-
 """
 __VERSION__ = "3-b2.2"
 __DATE__ = "20/June/2023"

--- a/fastlane_bot/config/__init__.py
+++ b/fastlane_bot/config/__init__.py
@@ -1,5 +1,12 @@
 """
 Fastlane bot configuration object
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 # from . import network, base, config, db, selectors, cloaker
 

--- a/fastlane_bot/config/__init__.py
+++ b/fastlane_bot/config/__init__.py
@@ -1,7 +1,24 @@
 """
-Fastlane bot configuration object
+Configuration-related classes
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+The classes into this module are
+
+- ``ConfigBase`` (``base``; base class)
+    - ``ConfigNetwork`` (``network``; network/chain)
+    - ``ConfigDB`` (``db``; database) -- DEPRECATED?
+    - ``ConfigLogger`` (``logger``; logging)
+    - ``ConfigProvider`` (``provider``; provider for network access) 
+- ``Config`` (``config``; main configuration class, integrates the above)
+
+Submodules provide the following
+
+- Constants (``constants`` and ``selectors``; various constants)
+- ``MultiCaller`` and related (``multicaller``; TODO: what is this?)
+- ``MultiProviderContractWrapper`` (``multiprovided``; TODO: what is this?)
+- ``NetworkBase`` and ``EthereumNetwork`` (``connect``; network/chain connection code TODO: details)
+- ``Cloaker`` (``cloaker``; deprecated)
+
+
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/config/base.py
+++ b/fastlane_bot/config/base.py
@@ -1,7 +1,8 @@
 """
-Base configuration class for the fastlane_bot application.
+Configuration base class
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+Defines `ConfigBase` which is the base class for the individual configuration classes
+in this module.
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/config/base.py
+++ b/fastlane_bot/config/base.py
@@ -1,6 +1,14 @@
 """
 Base configuration class for the fastlane_bot application.
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
+
 __VERSION__ = "1.1"
 __DATE__ = "30/Apr 2023"
 

--- a/fastlane_bot/config/cloaker.py
+++ b/fastlane_bot/config/cloaker.py
@@ -1,7 +1,15 @@
 """
-cloaking access to python files
+cloaking access to Python objects
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+NOTE: This class has been designed to be used with the Config object, to ensure
+that it can have private attributes that code using those objects cannot access.
+The idea was that this enforces clearer boundaries and therefore leads to better
+maintainability of the code. 
+
+It turns out that this feature has not been used, and unless it is found relevant
+in the redesign the code should be removed.
+
+TODO: unless decided otherwise, remove this code by July 2024
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.
@@ -22,7 +30,7 @@ class ShieldedAttribute():
     
 class Cloaker():
     """
-    Cloaking access to python files -- Base class
+    Cloaking access to Python objects -- Base class
     
     :cloaked_item:    the item to cloak
     

--- a/fastlane_bot/config/cloaker.py
+++ b/fastlane_bot/config/cloaker.py
@@ -1,9 +1,14 @@
 """
 cloaking access to python files
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
+
 __VERSION__ = "1.0-BETA1"
 __DATE__ = "26/Apr 2023"
 

--- a/fastlane_bot/config/config.py
+++ b/fastlane_bot/config/config.py
@@ -1,7 +1,10 @@
 """
-Fastlane bot configuration object -- main object
+Main configuration and context object
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+Defines the `Config` class which is the central source of truth for configuration
+and other context of the Fastlane bot.
+
+TODO: rewrite class doc strings in the appropriate format
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.
@@ -32,6 +35,8 @@ if TENDERLY_FORK_ID is None:
 class Config():
     """
     Fastlane bot configuration object
+    
+    NOTE: this class should be instantiated using the `new` classmethod, not directly.
     """
     __VERSION__ = __VERSION__
     __DATE__ = __DATE__

--- a/fastlane_bot/config/config.py
+++ b/fastlane_bot/config/config.py
@@ -1,6 +1,14 @@
 """
 Fastlane bot configuration object -- main object
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
+
 
 __VERSION__ = "1.0"
 __DATE__ = "03/May 2023"

--- a/fastlane_bot/config/connect.py
+++ b/fastlane_bot/config/connect.py
@@ -1,11 +1,13 @@
 """
 Networks module for fastlane - used to interact with the blockchain.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
-
-
 from abc import ABCMeta, ABC
 
 from eth_typing import HexStr

--- a/fastlane_bot/config/connect.py
+++ b/fastlane_bot/config/connect.py
@@ -1,7 +1,7 @@
 """
 Networks module for fastlane - used to interact with the blockchain.
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+TODO: what does it do exactly and how is it used? (TODO-MIKE or TODO-KEVIN)
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.
@@ -27,8 +27,6 @@ logger = logging.getLogger(__name__)
 # *******************************************************************************************
 # Singleton
 # *******************************************************************************************
-
-
 class Singleton(ABCMeta):
     """
     Singleton metaclass that enables the creation of a singleton object, as seen in this post:
@@ -45,8 +43,6 @@ class Singleton(ABCMeta):
 # *******************************************************************************************
 # Base Network
 # *******************************************************************************************
-
-
 class NetworkBase(ABC, metaclass=Singleton):
     """
     Base class for all networks - this is a singleton class that is used to interact with the blockchain
@@ -79,6 +75,9 @@ class NetworkBase(ABC, metaclass=Singleton):
         self.nonce = nonce
 
 
+# *******************************************************************************************
+# Ethereum Network
+# *******************************************************************************************
 class EthereumNetwork(NetworkBase):
     """
     Ethereum network class

--- a/fastlane_bot/config/constants.py
+++ b/fastlane_bot/config/constants.py
@@ -1,8 +1,12 @@
 """
-This file constains the constants used in the fastlane_bot package.
+This file contains the constants used in the fastlane_bot package.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT License.
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 
 FLASHLOAN_FEE_MAP = {

--- a/fastlane_bot/config/constants.py
+++ b/fastlane_bot/config/constants.py
@@ -1,7 +1,9 @@
 """
-This file contains the constants used in the fastlane_bot package.
+Hosts a number of constants used throughout the project.
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+TODO: this seems to be a pretty small and random collection of constants. Either
+many more should move here, or they should move elsewhere (note that they probably
+would feel right at home in the Config class).
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/config/db.py
+++ b/fastlane_bot/config/db.py
@@ -1,5 +1,12 @@
 """
 Fastlane bot config -- database configuration
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 __VERSION__ = "1.0.4"
 __DATE__ = "01/May 2023"

--- a/fastlane_bot/config/db.py
+++ b/fastlane_bot/config/db.py
@@ -1,7 +1,9 @@
 """
-Fastlane bot config -- database configuration
+Database configuration
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+NOTE: This class used to hold the database configuration when the bot still 
+used a database to hold state. As far as I believe databases are no longer
+in use so this module is deprecated? Is this true? TODO-MIKE
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/config/logger.py
+++ b/fastlane_bot/config/logger.py
@@ -1,5 +1,12 @@
 """
 Fastlane bot config -- logger
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 __VERSION__ = "1.0"
 __DATE__ = "03/May 2023"

--- a/fastlane_bot/config/logger.py
+++ b/fastlane_bot/config/logger.py
@@ -1,7 +1,8 @@
 """
-Fastlane bot config -- logger
+Logger configuration
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+NOTE: this whole logging business is a bit convoluted, so at one point
+we may consider cleaning it up
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.
@@ -18,8 +19,7 @@ from .base import ConfigBase
 from . import selectors as S
 import logging
 
-# NOTE: THIS WHOLE LOGGING BUSINESS IS A BIT CONVOLUTED, SO AT ONE POINT
-# WE MAY CONSIDER CLEANING IT UP
+
 
 class ConfigLogger(ConfigBase):
     """

--- a/fastlane_bot/config/multicaller.py
+++ b/fastlane_bot/config/multicaller.py
@@ -1,14 +1,13 @@
 """
-This is the multicaller module.
+This is the multicaller module. TODO: BETTER NAME
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+TODO-MIKE: What exactly does this do and is it a bona fide config module?
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.
 All rights reserved.
 Licensed under MIT.
 """
-
 from functools import partial
 from typing import List, Callable, ContextManager, Any, Dict
 

--- a/fastlane_bot/config/multicaller.py
+++ b/fastlane_bot/config/multicaller.py
@@ -1,10 +1,14 @@
-# coding=utf-8
 """
 This is the multicaller module.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
+
 from functools import partial
 from typing import List, Callable, ContextManager, Any, Dict
 

--- a/fastlane_bot/config/multiprovider.py
+++ b/fastlane_bot/config/multiprovider.py
@@ -1,7 +1,8 @@
 """
-[DOC-TODO-short description of what the file does, max 80 chars]
+Defines the ``MultiProviderContractWrapper`` class 
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+TODO-MIKE: This is a very short module, so maybe the code should move somewhere else;
+also -- should it really be in config?
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/config/multiprovider.py
+++ b/fastlane_bot/config/multiprovider.py
@@ -1,3 +1,13 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""
 from web3 import Web3
 from typing import Dict
 

--- a/fastlane_bot/config/network.py
+++ b/fastlane_bot/config/network.py
@@ -1,5 +1,12 @@
 """
 Fastlane bot config -- network
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 __VERSION__ = "1.0.3-RESTRICTED"
 __DATE__ = "02/May 2023"

--- a/fastlane_bot/config/network.py
+++ b/fastlane_bot/config/network.py
@@ -1,7 +1,7 @@
 """
-Fastlane bot config -- network
+Network configuration (defines the ``ConfigNetwork`` class)
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+Used to configure the network for the fastlane bot.
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/config/provider.py
+++ b/fastlane_bot/config/provider.py
@@ -1,5 +1,5 @@
 """
-Fastlane bot config -- provider
+Provider configuration (provides the ``ConfigProvider`` class)
 
 [DOC-TODO-OPTIONAL-longer description in rst format]
 

--- a/fastlane_bot/config/provider.py
+++ b/fastlane_bot/config/provider.py
@@ -1,6 +1,14 @@
 """
 Fastlane bot config -- provider
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
+
 __VERSION__ = "0.9.1"
 __DATE__ = "30/Apr 2023"
 

--- a/fastlane_bot/config/selectors.py
+++ b/fastlane_bot/config/selectors.py
@@ -1,5 +1,5 @@
 """
-Fastlane bot configuration object -- selector constants
+Selector constants
 
 [DOC-TODO-OPTIONAL-longer description in rst format]
 

--- a/fastlane_bot/config/selectors.py
+++ b/fastlane_bot/config/selectors.py
@@ -1,5 +1,12 @@
 """
 Fastlane bot configuration object -- selector constants
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 
 NETWORK_ETHEREUM = "ethereum"

--- a/fastlane_bot/data/__init__.py
+++ b/fastlane_bot/data/__init__.py
@@ -1,0 +1,10 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""

--- a/fastlane_bot/data/__init__.py
+++ b/fastlane_bot/data/__init__.py
@@ -1,7 +1,12 @@
 """
-[DOC-TODO-short description of what the file does, max 80 chars]
+Static data used by the bot, including ABIs
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+NOTE: This directory contains static data used by the bot. Most of this data is in
+json or csv files and therefore needs to be read using standard file I/O. 
+The exception is ABI data which is imported as a Python data structures.
+
+TODO: possibly this data should be provided for remote download from a server, as
+the ideal update frequency is higher than the bot's release frequency.
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/data/abi.py
+++ b/fastlane_bot/data/abi.py
@@ -1,7 +1,14 @@
 """
-ABI's for the contracts used in the FastLane project
+ABI's for the EVM contracts interfaced
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+Contains the following ABI's:
+
+- ``FAST_LANE_CONTRACT_ABI``: FastLane arbitrage contract
+- ``ERC20_ABI``: generic ERC20 token contract
+- ``SUSHISWAP_FACTORY_ABI``: Sushiswap factory contract
+- ``SUSHISWAP_ROUTER_ABI``: Sushiswap router contract
+- ``SUSHISWAP_POOLS_ABI``: Sushiswap pools contract
+- other ABIs of exchanges we support
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/data/abi.py
+++ b/fastlane_bot/data/abi.py
@@ -1,8 +1,12 @@
 """
 ABI's for the contracts used in the FastLane project
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 
 FAST_LANE_CONTRACT_ABI = [

--- a/fastlane_bot/events/__init__.py
+++ b/fastlane_bot/events/__init__.py
@@ -1,0 +1,10 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""

--- a/fastlane_bot/events/async_backdate_utils.py
+++ b/fastlane_bot/events/async_backdate_utils.py
@@ -1,3 +1,13 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""
 import asyncio
 import time
 from typing import Any, Dict, Tuple, List

--- a/fastlane_bot/events/async_event_update_utils.py
+++ b/fastlane_bot/events/async_event_update_utils.py
@@ -1,3 +1,13 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""
 import asyncio
 import os
 import time

--- a/fastlane_bot/events/async_utils.py
+++ b/fastlane_bot/events/async_utils.py
@@ -1,3 +1,13 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""
 import os
 from typing import Any, List, Dict
 

--- a/fastlane_bot/events/exchanges/__init__.py
+++ b/fastlane_bot/events/exchanges/__init__.py
@@ -1,11 +1,13 @@
-# coding=utf-8
 """
 Contains the exchanges classes
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
-"""
+[DOC-TODO-OPTIONAL-longer description in rst format]
 
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""
 from fastlane_bot.events.exchanges.bancor_v3 import BancorV3
 from fastlane_bot.events.exchanges.carbon_v1 import CarbonV1
 from fastlane_bot.events.exchanges.factory import ExchangeFactory

--- a/fastlane_bot/events/exchanges/balancer.py
+++ b/fastlane_bot/events/exchanges/balancer.py
@@ -1,9 +1,15 @@
-# coding=utf-8
 """
-Contains the exchange class for Balancer weighted pools. This class is responsible for handling Balancer exchanges and updating the state of the pools.
+Contains the exchange class for Balancer Weighted Pools. 
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+This class is responsible for handling Balancer Weighted Pools events and updating the state of the pools.
+
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import List, Type, Tuple, Any

--- a/fastlane_bot/events/exchanges/bancor_pol.py
+++ b/fastlane_bot/events/exchanges/bancor_pol.py
@@ -1,9 +1,15 @@
-# coding=utf-8
 """
-Contains the exchange class for BancorV3. This class is responsible for handling BancorV3 events and updating the state of the pools.
+Contains the exchange class for Bancor POL. 
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+This class is responsible for handling Bancor POL events and updating the state of the pools.
+
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import List, Type, Tuple, Any, Dict, Callable

--- a/fastlane_bot/events/exchanges/bancor_v2.py
+++ b/fastlane_bot/events/exchanges/bancor_v2.py
@@ -1,9 +1,15 @@
-# coding=utf-8
 """
-Contains the exchange class for bancorV2. This class is responsible for handling bancorV2 exchanges and updating the state of the pools.
+Contains the exchange class for BancorV2. 
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+This class is responsible for handling BancorV2 events and updating the state of the pools.
+
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import List, Type, Tuple, Any

--- a/fastlane_bot/events/exchanges/bancor_v3.py
+++ b/fastlane_bot/events/exchanges/bancor_v3.py
@@ -1,9 +1,15 @@
-# coding=utf-8
 """
-Contains the exchange class for BancorV3. This class is responsible for handling BancorV3 events and updating the state of the pools.
+Contains the exchange class for BancorV3. 
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+This class is responsible for handling BancorV3 events and updating the state of the pools.
+
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import List, Type, Tuple, Any

--- a/fastlane_bot/events/exchanges/base.py
+++ b/fastlane_bot/events/exchanges/base.py
@@ -1,9 +1,14 @@
-# coding=utf-8
 """
-Contains the base class for exchanges. This class is responsible for handling exchanges and updating the state of the pools.
+Contains the base class for exchanges. 
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+This class is responsible for handling exchanges and updating the state of the pools.
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field

--- a/fastlane_bot/events/exchanges/carbon_v1.py
+++ b/fastlane_bot/events/exchanges/carbon_v1.py
@@ -1,9 +1,15 @@
-# coding=utf-8
 """
-Contains the exchange class for CarbonV1. This class is responsible for handling CarbonV1 events and updating the state of the pools.
+Contains the exchange class for CarbonV1. 
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+This class is responsible for handling CarbonV1 events and updating the state of the pools.
+
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import List, Type, Tuple, Any, Dict, Callable

--- a/fastlane_bot/events/exchanges/factory.py
+++ b/fastlane_bot/events/exchanges/factory.py
@@ -1,9 +1,14 @@
-# coding=utf-8
 """
-Contains the factory class for exchanges. This class is responsible for creating exchanges.
+Contains the factory class for exchanges. 
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+This class is responsible for creating exchanges.
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from typing import Dict, Any
 

--- a/fastlane_bot/events/exchanges/solidly_v2.py
+++ b/fastlane_bot/events/exchanges/solidly_v2.py
@@ -1,9 +1,15 @@
-# coding=utf-8
 """
-Contains the exchange class for UniswapV2. This class is responsible for handling UniswapV2 exchanges and updating the state of the pools.
+Contains the exchange class for SolidlyV2. 
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+This class is responsible for handling SolidlyV2 events and updating the state of the pools.
+
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import List, Type, Tuple, Any

--- a/fastlane_bot/events/exchanges/uniswap_v2.py
+++ b/fastlane_bot/events/exchanges/uniswap_v2.py
@@ -1,9 +1,15 @@
-# coding=utf-8
 """
-Contains the exchange class for UniswapV2. This class is responsible for handling UniswapV2 exchanges and updating the state of the pools.
+Contains the exchange class for UniswapV2. 
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+This class is responsible for handling UniswapV2 events and updating the state of the pools.
+
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import List, Type, Tuple, Any

--- a/fastlane_bot/events/exchanges/uniswap_v3.py
+++ b/fastlane_bot/events/exchanges/uniswap_v3.py
@@ -1,9 +1,15 @@
-# coding=utf-8
 """
-Contains the exchange class for BancorV3. This class is responsible for handling BancorV3 events and updating the state of the pools.
+Contains the exchange class for UniswapV3. 
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+This class is responsible for handling UniswapV3 events and updating the state of the pools.
+
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import List, Type, Tuple, Any

--- a/fastlane_bot/events/interface.py
+++ b/fastlane_bot/events/interface.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Contains the interface for querying data from the data fetcher module.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass, field
 from typing import List, Any, Dict, Optional

--- a/fastlane_bot/events/managers/__init__.py
+++ b/fastlane_bot/events/managers/__init__.py
@@ -1,0 +1,10 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""

--- a/fastlane_bot/events/managers/base.py
+++ b/fastlane_bot/events/managers/base.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Contains the base class for the managers modules.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 import time
 from dataclasses import dataclass, field

--- a/fastlane_bot/events/managers/contracts.py
+++ b/fastlane_bot/events/managers/contracts.py
@@ -1,10 +1,15 @@
-# coding=utf-8
 """
 Contains the manager module for handling contract functionality within the events updater.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
+
 import os.path
 import random
 from datetime import datetime

--- a/fastlane_bot/events/managers/events.py
+++ b/fastlane_bot/events/managers/events.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Contains the events manager module for handling event related functionality of data fetching.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from typing import Dict, Any, List, Type, Tuple
 

--- a/fastlane_bot/events/managers/manager.py
+++ b/fastlane_bot/events/managers/manager.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Contains the manager class for events. This class is responsible for handling events and updating the state of the pools.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 import random
 import time

--- a/fastlane_bot/events/managers/pools.py
+++ b/fastlane_bot/events/managers/pools.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Contains the manager class for pools. This class is responsible for handling pools and updating their state.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from typing import List, Dict, Any, Callable, Optional
 

--- a/fastlane_bot/events/multicall_utils.py
+++ b/fastlane_bot/events/multicall_utils.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 This is the multicaller utils module.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from decimal import Decimal
 from typing import Dict, Any

--- a/fastlane_bot/events/pools/__init__.py
+++ b/fastlane_bot/events/pools/__init__.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Contains the pools classes
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from fastlane_bot.events.pools.bancor_v3 import BancorV3Pool
 from fastlane_bot.events.pools.carbon_v1 import CarbonV1Pool

--- a/fastlane_bot/events/pools/balancer.py
+++ b/fastlane_bot/events/pools/balancer.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
-Contains the pool class for Carbon v1. This class is responsible for handling Carbon v1 pools and updating the state of the pools.
+[DOC-TODO-short description of what the file does, max 80 chars]
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import Dict, Any, List

--- a/fastlane_bot/events/pools/bancor_pol.py
+++ b/fastlane_bot/events/pools/bancor_pol.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
-Contains the exchange class for BancorV3. This class is responsible for handling BancorV3 events and updating the state of the pools.
+[DOC-TODO-short description of what the file does, max 80 chars]
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import Dict, Any, List

--- a/fastlane_bot/events/pools/bancor_v2.py
+++ b/fastlane_bot/events/pools/bancor_v2.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
-Contains the pool class for bancor v2. This class is responsible for handling bancor v2 pools and updating the state of the pools.
+[DOC-TODO-short description of what the file does, max 80 chars]
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import Dict, Any, List

--- a/fastlane_bot/events/pools/bancor_v3.py
+++ b/fastlane_bot/events/pools/bancor_v3.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
-Contains the exchange class for BancorV3. This class is responsible for handling BancorV3 events and updating the state of the pools.
+[DOC-TODO-short description of what the file does, max 80 chars]
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import Dict, Any, List

--- a/fastlane_bot/events/pools/base.py
+++ b/fastlane_bot/events/pools/base.py
@@ -1,9 +1,14 @@
-# coding=utf-8
 """
-Contains the base class for pools. This class is responsible for handling pools and updating the state of the pools.
+Contains the base class for pools. 
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+This class is responsible for handling pools and updating the state of the pools.
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field

--- a/fastlane_bot/events/pools/carbon_v1.py
+++ b/fastlane_bot/events/pools/carbon_v1.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
-Contains the pool class for Carbon v1. This class is responsible for handling Carbon v1 pools and updating the state of the pools.
+[DOC-TODO-short description of what the file does, max 80 chars]
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import Dict, Any, Tuple, List

--- a/fastlane_bot/events/pools/factory.py
+++ b/fastlane_bot/events/pools/factory.py
@@ -1,9 +1,14 @@
-# coding=utf-8
 """
-Contains the factory class for pools. This class is responsible for creating pools.
+Contains the factory class for pools. 
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+This class is responsible for creating pools.
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from typing import Any, Dict
 

--- a/fastlane_bot/events/pools/solidly_v2.py
+++ b/fastlane_bot/events/pools/solidly_v2.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
-Contains the pool class for Uniswap v2. This class is responsible for handling Uniswap v2 pools and updating the state of the pools.
+[DOC-TODO-short description of what the file does, max 80 chars]
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import Dict, Any, List

--- a/fastlane_bot/events/pools/uniswap_v2.py
+++ b/fastlane_bot/events/pools/uniswap_v2.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
-Contains the pool class for Uniswap v2. This class is responsible for handling Uniswap v2 pools and updating the state of the pools.
+[DOC-TODO-short description of what the file does, max 80 chars]
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import Dict, Any, List

--- a/fastlane_bot/events/pools/uniswap_v3.py
+++ b/fastlane_bot/events/pools/uniswap_v3.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
-Contains the pool class for Uniswap v3. This class is responsible for handling Uniswap v3 pools and updating the state of the pools.
+[DOC-TODO-short description of what the file does, max 80 chars]
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from dataclasses import dataclass
 from typing import Dict, Any, List

--- a/fastlane_bot/events/utils.py
+++ b/fastlane_bot/events/utils.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Contains the utils functions for events
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 import base64
 import json

--- a/fastlane_bot/events/version_utils.py
+++ b/fastlane_bot/events/version_utils.py
@@ -1,3 +1,13 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""
 from packaging import version as pkg_version
 from importlib.metadata import version
 

--- a/fastlane_bot/exceptions.py
+++ b/fastlane_bot/exceptions.py
@@ -1,7 +1,9 @@
 """
-[DOC-TODO-short description of what the file does, max 80 chars]
+Collects exceptions used by the code
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+NOTE: Use of this module is not consistent throughout the codebase. In fact, most exceptions
+are defined locally either a module or at class level. Also this file is relatively short
+and we should review whether this design makes sense (TODO)
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/exceptions.py
+++ b/fastlane_bot/exceptions.py
@@ -1,3 +1,13 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""
 class ReadOnlyException(Exception):
     def __init__(self, filepath):
         self.filepath = filepath

--- a/fastlane_bot/helpers/__init__.py
+++ b/fastlane_bot/helpers/__init__.py
@@ -1,3 +1,13 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""
 from .tradeinstruction import TradeInstruction 
 from .routehandler import TxRouteHandler, RouteStruct
 from .submithandler import submit_transaction_tenderly

--- a/fastlane_bot/helpers/carbon_trade_splitter.py
+++ b/fastlane_bot/helpers/carbon_trade_splitter.py
@@ -1,3 +1,13 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""
 from typing import List
 from json import loads, dumps
 from fastlane_bot.config import Config

--- a/fastlane_bot/helpers/carbon_trade_splitter.py
+++ b/fastlane_bot/helpers/carbon_trade_splitter.py
@@ -1,7 +1,9 @@
 """
-[DOC-TODO-short description of what the file does, max 80 chars]
+Helper function to split Carbon trades into multiple trades, eg if ETH and WETH is involved
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+Defines the ``split_carbon_trades`` function 
+
+TODO: maybe this should be moved into a slightly bigger context
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/helpers/poolandtokens.py
+++ b/fastlane_bot/helpers/poolandtokens.py
@@ -1,3 +1,13 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""
 __VERSION__ = "1.2"
 __DATE__ = "05/May/2023"
 

--- a/fastlane_bot/helpers/poolandtokens.py
+++ b/fastlane_bot/helpers/poolandtokens.py
@@ -1,7 +1,5 @@
 """
-[DOC-TODO-short description of what the file does, max 80 chars]
-
-[DOC-TODO-OPTIONAL-longer description in rst format]
+Defines the ``PoolAndTokens`` class, representing a pool and its tokens in a single object. This is not a database model, but a helper class.
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/helpers/routehandler.py
+++ b/fastlane_bot/helpers/routehandler.py
@@ -1,8 +1,12 @@
 """
 Route handler for the Fastlane project.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 __VERSION__ = "1.1.1"
 __DATE__ = "02/May/2023"

--- a/fastlane_bot/helpers/routehandler.py
+++ b/fastlane_bot/helpers/routehandler.py
@@ -1,8 +1,13 @@
 """
 Route handler for the Fastlane project.
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+Main classes defined here are
 
+- ``RouteStruct``: represents a single trade route
+- ``TxRouteHandler``: converts trade instructions from the optimizer into routes
+
+It also defines a few helper function that should not be relied upon by external modules,
+even if they happen to be exported.
 ---
 (c) Copyright Bprotocol foundation 2023-24.
 All rights reserved.
@@ -66,6 +71,10 @@ def maximize_last_trade_per_tkn(route_struct: List[Dict[str, Any]]) -> List[Dict
     """
     Sets the source amount of the last trade to 0 per-token, ensuring that all tokens held will be used in the last trade.
 
+    TODO: this function seems to be only used in this module and therefore should
+    be made a private function (_maximize_last_trade_per_tkn); I also would suggest
+    to move it to the TxRouteHandler class, either as static or class method.
+    
     :param route_struct: the route struct object
 
     Returns:
@@ -115,7 +124,7 @@ class TxRouteHandler:
         if not self.trade_instructions:
             raise ValueError("No trade instructions found.")
         if len(self.trade_instructions) < 2:
-            raise ValueError("Trade instructions must be greater than 1.")
+            raise ValueError("Length of trade instructions must be greater than 1.")
         if sum([1 if self.trade_instructions[i]._is_carbon else 0 for i in range(len(self.trade_instructions))]) == 0:
             self.contains_carbon = False
 
@@ -1479,6 +1488,8 @@ class TxRouteHandler:
     def _cid_to_pool(self, cid: str, db: any) -> Pool:
         return db.get_pool(cid=cid)
 
+# TODO: Those functions should probably be private; also -- are they needed at
+# all? Most of them seem to be extremely trivial
 
 def mulUp(a: Decimal, b: Decimal) -> Decimal:
     return a * b

--- a/fastlane_bot/helpers/submithandler.py
+++ b/fastlane_bot/helpers/submithandler.py
@@ -1,7 +1,9 @@
 """
 Submit handler for the Fastlane project.
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+TODO: despite the naming of the module, it currently ONLY seems to support Tenderly
+submission, via the ``submit_transaction_tenderly`` function. Either the module should
+be renamed or, better, the code should be consolidated
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.
@@ -15,6 +17,9 @@ from typing import List, Any, Dict
 from .routehandler import RouteStruct
 from ..data.abi import FAST_LANE_CONTRACT_ABI
 from fastlane_bot.config import Config
+
+# TODO: splitting this into two functions does not seem to be particularly useful
+# given how little the wrapping code does
 
 def submit_transaction_tenderly(
     cfg: Config,

--- a/fastlane_bot/helpers/submithandler.py
+++ b/fastlane_bot/helpers/submithandler.py
@@ -1,8 +1,12 @@
 """
 Submit handler for the Fastlane project.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 __VERSION__ = "1.0"
 __DATE__ = "01/May/2023"

--- a/fastlane_bot/helpers/tradeinstruction.py
+++ b/fastlane_bot/helpers/tradeinstruction.py
@@ -1,7 +1,9 @@
 """
-Helpers for the Fastlane project.
+Defines the ``TradeInstruction`` class.
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+TODO: check what this class actually does; in the docstring it says
+_A class that handles the conversion of token decimals for the bot._
+which does not seem to be the case.
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.
@@ -23,6 +25,8 @@ class TradeInstruction:
     """
     A class that handles the conversion of token decimals for the bot.
 
+    TODO: doc string not in line with code
+    
     Parameters
     ----------
     cid: str

--- a/fastlane_bot/helpers/tradeinstruction.py
+++ b/fastlane_bot/helpers/tradeinstruction.py
@@ -1,9 +1,14 @@
 """
 Helpers for the Fastlane project.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
+
 __VERSION__ = "1.2"
 __DATE__="02/May/2023"
 

--- a/fastlane_bot/helpers/txhelpers.py
+++ b/fastlane_bot/helpers/txhelpers.py
@@ -1,7 +1,19 @@
 """
-Transaction handlers for the Fastlane project.
+Defines a collection of transaction-related helper functions
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+This module defines the ``TxHelpers`` class, which provides a collection of properties
+and methods for working with transactions:
+
+- ``validate_and_submit_transaction``: Validates a transaction and then submits it to the arb contract
+- ``get_access_list``: TODO
+- ``construct_contract_function``: Builds a transaction using the Arb Contract function
+- ``build_transaction_with_gas``: Builds a transaction (how is it different from ``construct_contract_function``?)
+- ``get_nonce``: Returns the nonce of the wallet address
+- ``build_tx``: Yet another method for building a transaction (TODO)
+- ``submit_regular_transaction``: Submits a non-private transaction to the blockchain
+- ``submit_private_transaction``: Ditto private
+- ``sign_transaction``: Signs a transaction
+- ...
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.
@@ -230,6 +242,7 @@ class TxHelpers:
             return None
 
     def get_access_list(self, transaction_data, expected_gas, eth_input=None):
+        """TODO: docstring"""
         expected_gas = hex(expected_gas)
         json_data = (
             {

--- a/fastlane_bot/helpers/txhelpers.py
+++ b/fastlane_bot/helpers/txhelpers.py
@@ -1,8 +1,12 @@
 """
 Transaction handlers for the Fastlane project.
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 __VERSION__ = "1.0"
 __DATE__ = "01/May/2023"

--- a/fastlane_bot/helpers/univ3calc.py
+++ b/fastlane_bot/helpers/univ3calc.py
@@ -1,12 +1,14 @@
 """
 translating Uniswap v3 contract values
 
-(c) Copyright Bprotocol foundation 2023. 
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
 
-NOTE: this class is not part of the API of the Carbon protocol, and you must expect breaking
-changes even in minor version updates. Use at your own risk.
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
+
 __VERSION__ = "1.4.1" 
 __DATE__ = "25/Jul/2023"
 

--- a/fastlane_bot/helpers/univ3calc.py
+++ b/fastlane_bot/helpers/univ3calc.py
@@ -1,7 +1,10 @@
 """
-translating Uniswap v3 contract values
+parsing Uniswap v3 contract values
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+This class converts internal Uniswap v3 contract values into values that make sense
+from a financial perspective, either in Wei or in token units. It also allows to
+convert Uniswap v3 contract parameters into generic constant product curve parameters
+that are suitable for our ``CPC`` class.
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/helpers/wrap_unwrap_processor.py
+++ b/fastlane_bot/helpers/wrap_unwrap_processor.py
@@ -1,3 +1,13 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""
 from typing import List
 from dataclasses import asdict
 from fastlane_bot.config import Config

--- a/fastlane_bot/helpers/wrap_unwrap_processor.py
+++ b/fastlane_bot/helpers/wrap_unwrap_processor.py
@@ -1,7 +1,9 @@
 """
-[DOC-TODO-short description of what the file does, max 80 chars]
+Deals with wrap and unwrap trades (eg WETH <-> ETH) in the route.
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+Defines the ``add_wrap_or_unwrap_trades_to_route`` method.
+
+TODO: see whether to consolidate this with other objects
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/modes/__init__.py
+++ b/fastlane_bot/modes/__init__.py
@@ -1,0 +1,10 @@
+"""
+[DOC-TODO-short description of what the file does, max 80 chars]
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""

--- a/fastlane_bot/modes/__init__.py
+++ b/fastlane_bot/modes/__init__.py
@@ -1,7 +1,38 @@
 """
-[DOC-TODO-short description of what the file does, max 80 chars]
+Finds the arbitrage opportunities once the data has been read
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+Whilst the Optimizer can work with any number of curves, the arbitrages found
+are not _linear_ in the sense that they may require significant initial token 
+balances in multiple tokens to execute, and those balances are only certain to
+be repaid at the end.
+
+What we generally want is _linear_ transaction where we start with one token
+that we can obtain in a flashloan, that we then pass through a series of
+exchanges without having to borrow additional tokens, and that are repaid at
+the end.
+
+Creating such linear transaction in the generic case is complex, and the longer
+the transaction the more likely is that by the time that it has been submitted
+on part of the chain has gone and the entire transaction fails.
+
+The way we deal with this issue is that we are looking specifically for _pairwise_ 
+and _triangle_ arbitrages, the former only operating on a single pair, and the
+latter operating on all pairs that are based on a fixed set of three tokens. 
+
+In order to find and evaluate those arbitrages there is a hierarchy of classes
+that are defined in this module
+
+- ``ArbitrageFinderBase`` (``base``): fundamental base class
+    - ``ArbitrageFinderPairwiseBase`` (``base_pairwise``): base class for pairwise arbitrages
+        - ``FindArbitrageSinglePairwise`` (``pairwise_single``)
+        - ``FindArbitrageMultiPairwise`` (``pairwise_multi``)
+        - ``FindArbitrageMultiPairwiseAll`` (``pairwise_multi_all``)
+        - ``FindArbitrageMultiPairwisePol`` (``pairwise_multi_pol``)
+    - ``ArbitrageFinderTriangleBase`` (``base_triangle``): base class for triangle arbitrages    
+        - ``ArbitrageFinderTriangleSingle`` (``triangle_single``)
+        - ``ArbitrageFinderTriangleMulti`` (``triangle_multi``)
+        - ``ArbitrageFinderTriangleBancor3TwoHop`` (``triangle_bancor_v3_two_hop``)
+
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.

--- a/fastlane_bot/modes/base.py
+++ b/fastlane_bot/modes/base.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Base class for all arbitrage finder modes
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 import abc
 from typing import Any, Tuple, Dict, List, Union

--- a/fastlane_bot/modes/base.py
+++ b/fastlane_bot/modes/base.py
@@ -1,5 +1,5 @@
 """
-Base class for all arbitrage finder modes
+Defines the base class for all arbitrage finder modes
 
 [DOC-TODO-OPTIONAL-longer description in rst format]
 

--- a/fastlane_bot/modes/base_pairwise.py
+++ b/fastlane_bot/modes/base_pairwise.py
@@ -1,5 +1,5 @@
 """
-Base class for pairwise arbitrage finder modes
+Defines the base class for pairwise arbitrage finder modes
 
 [DOC-TODO-OPTIONAL-longer description in rst format]
 

--- a/fastlane_bot/modes/base_pairwise.py
+++ b/fastlane_bot/modes/base_pairwise.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Base class for pairwise arbitrage finder modes
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 import abc
 import itertools

--- a/fastlane_bot/modes/base_triangle.py
+++ b/fastlane_bot/modes/base_triangle.py
@@ -1,5 +1,5 @@
 """
-Base class for triangular arbitrage finder modes
+Defines the base class for triangular arbitrage finder modes
 
 [DOC-TODO-OPTIONAL-longer description in rst format]
 

--- a/fastlane_bot/modes/base_triangle.py
+++ b/fastlane_bot/modes/base_triangle.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Base class for triangular arbitrage finder modes
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 import abc
 import itertools

--- a/fastlane_bot/modes/pairwise_multi.py
+++ b/fastlane_bot/modes/pairwise_multi.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Multi-pairwise arbitrage finder mode
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from typing import List, Any, Tuple, Union, Hashable
 

--- a/fastlane_bot/modes/pairwise_multi.py
+++ b/fastlane_bot/modes/pairwise_multi.py
@@ -1,5 +1,5 @@
 """
-Multi-pairwise arbitrage finder mode
+Defines the Multi-pairwise arbitrage finder class
 
 [DOC-TODO-OPTIONAL-longer description in rst format]
 

--- a/fastlane_bot/modes/pairwise_multi_all.py
+++ b/fastlane_bot/modes/pairwise_multi_all.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Multi-pairwise arbitrage finder mode
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 import itertools
 from typing import List, Any, Tuple, Union, Hashable

--- a/fastlane_bot/modes/pairwise_multi_all.py
+++ b/fastlane_bot/modes/pairwise_multi_all.py
@@ -1,5 +1,5 @@
 """
-Multi-pairwise arbitrage finder mode
+Defines the Multi-pairwise arbitrage finder class
 
 [DOC-TODO-OPTIONAL-longer description in rst format]
 

--- a/fastlane_bot/modes/pairwise_multi_pol.py
+++ b/fastlane_bot/modes/pairwise_multi_pol.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Multi-pairwise arbitrage finder mode
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from typing import List, Any, Tuple, Union, Hashable
 

--- a/fastlane_bot/modes/pairwise_multi_pol.py
+++ b/fastlane_bot/modes/pairwise_multi_pol.py
@@ -1,5 +1,5 @@
 """
-Multi-pairwise arbitrage finder mode
+Defines the Multi-pairwise arbitrage finder class for Bancor POL
 
 [DOC-TODO-OPTIONAL-longer description in rst format]
 
@@ -20,7 +20,7 @@ from fastlane_bot.tools.cpc import T
 
 class FindArbitrageMultiPairwisePol(ArbitrageFinderPairwiseBase):
     """
-    Multi-pairwise arbitrage finder mode.
+    Multi-pairwise arbitrage finder mode for Bancor POL.
     """
 
     arb_mode = "multi_pairwise_pol"

--- a/fastlane_bot/modes/pairwise_single.py
+++ b/fastlane_bot/modes/pairwise_single.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Single pairwise arbitrage finder mode
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from typing import List, Any, Tuple, Union
 

--- a/fastlane_bot/modes/pairwise_single.py
+++ b/fastlane_bot/modes/pairwise_single.py
@@ -1,5 +1,5 @@
 """
-Single pairwise arbitrage finder mode
+Defines the Single pairwise arbitrage finder class
 
 [DOC-TODO-OPTIONAL-longer description in rst format]
 

--- a/fastlane_bot/modes/triangle_bancor_v3_two_hop.py
+++ b/fastlane_bot/modes/triangle_bancor_v3_two_hop.py
@@ -1,5 +1,5 @@
 """
-Bancor V3 triangular arbitrage finder mode
+Defines the Bancor V3 triangular arbitrage finder class
 
 [DOC-TODO-OPTIONAL-longer description in rst format]
 

--- a/fastlane_bot/modes/triangle_bancor_v3_two_hop.py
+++ b/fastlane_bot/modes/triangle_bancor_v3_two_hop.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Bancor V3 triangular arbitrage finder mode
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 import math
 from typing import Union, List, Tuple, Any, Iterable

--- a/fastlane_bot/modes/triangle_multi.py
+++ b/fastlane_bot/modes/triangle_multi.py
@@ -1,5 +1,5 @@
 """
-Triangular arbitrage finder mode
+Defines the Triangular arbitrage finder class
 
 [DOC-TODO-OPTIONAL-longer description in rst format]
 

--- a/fastlane_bot/modes/triangle_multi.py
+++ b/fastlane_bot/modes/triangle_multi.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Triangular arbitrage finder mode
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from typing import List, Any, Tuple, Union
 

--- a/fastlane_bot/modes/triangle_single.py
+++ b/fastlane_bot/modes/triangle_single.py
@@ -1,5 +1,5 @@
 """
-Triangle single arbitrage finder mode
+Defines the Triangle single arbitrage finder class
 
 [DOC-TODO-OPTIONAL-longer description in rst format]
 

--- a/fastlane_bot/modes/triangle_single.py
+++ b/fastlane_bot/modes/triangle_single.py
@@ -1,9 +1,12 @@
-# coding=utf-8
 """
 Triangle single arbitrage finder mode
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 from typing import Union, List, Tuple, Any
 

--- a/fastlane_bot/testing.py
+++ b/fastlane_bot/testing.py
@@ -1,11 +1,18 @@
 """
 Testing utilities for the fastlane_bot package
 
-USAGE
+This module defines a number of functions that are useful for testing purposes, and
+testing code would typically start with
+```
+from fastlane_bot.testing import *
+...
+```
 
-    from fastlane_bot.testing import *
-
-[DOC-TODO-OPTIONAL-longer description in rst format]
+It defines the following functions
+- ``iseq``: checks for float equality (within tolerance)
+- ``raises``: allows asserting that an exception is raised
+- ``require``: allows asserting that minimum version requirements are met
+- ``Timer``: allow simple wall-clock-based timing of code execution
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.
@@ -130,11 +137,14 @@ class Timer():
         Timer.t1(func, args, N=100_000)
         Timer.t2(func, arg1, arg2, N=100_000)
         
-    Note: the default value for N can be changed by using a derived class, eg:
+    NOTE: the default value for N can be changed by using a derived class, eg:
         
         class MyTimer(Timer):
             N = 1_000_000
         MyTimer.t(func, *args, *kwargs)
+        
+    WARNING: the timer is based on wall-clock time which may not be appropriate for
+    timing on multi-process systems
     """
     N = 1_000_000
         

--- a/fastlane_bot/testing.py
+++ b/fastlane_bot/testing.py
@@ -4,6 +4,13 @@ Testing utilities for the fastlane_bot package
 USAGE
 
     from fastlane_bot.testing import *
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 __VERSION__ = "1.3"
 __DATE__ = "15/Jan/2024"

--- a/fastlane_bot/utils.py
+++ b/fastlane_bot/utils.py
@@ -1,8 +1,12 @@
 """
 Utility functions for FastLane project
 
-(c) Copyright Bprotocol foundation 2023.
-Licensed under MIT
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
 """
 import datetime
 import glob

--- a/fastlane_bot/utils.py
+++ b/fastlane_bot/utils.py
@@ -1,7 +1,8 @@
 """
-Utility functions for FastLane project
+Various utility functions
 
-[DOC-TODO-OPTIONAL-longer description in rst format]
+NOTE: Those functions would more naturally fit in `helpers` 
+TODO-MIKE, TODO-KEVIN: check how hard this is
 
 ---
 (c) Copyright Bprotocol foundation 2023-24.


### PR DESCRIPTION
Fixes #438 

Adds doc strings to all files that do not have them

All files should have a docstring of the following format

```
"""
[DOC-TODO-short description of what the file does, max 80 chars]

[DOC-TODO-OPTIONAL-longer description in rst format]

---
(c) Copyright Bprotocol foundation 2023-24.
All rights reserved.
Licensed under MIT.
"""