### PR TITLE
Fix args kwargs usage in build transaction generic

### DIFF
--- a/fastlane_bot/events/managers/base.py
+++ b/fastlane_bot/events/managers/base.py
@@ -116,7 +116,6 @@ class BaseManager:
             initialize_events = False
             base_exchange_name = self.cfg.network.exchange_name_base_from_fork(exchange_name=exchange_name)
             if exchange_name in [PANCAKESWAP_V2_NAME, PANCAKESWAP_V3_NAME, VELOCIMETER_V2_NAME, AGNI_V3_NAME]:
-                print(f"initializing {exchange_name}")
                 initialize_events = True
             elif base_exchange_name not in initialized_exchanges:
                 initialize_events = True
@@ -177,7 +176,6 @@ class BaseManager:
         Set the carbon v1 fee pairs.
         """
         for ex in [ex for ex in self.cfg.CARBON_V1_FORKS if ex in self.exchanges]:
-            print(f"Setting {ex} fee pairs...")
             # Create or get CarbonController contract object
             carbon_controller = self.create_or_get_carbon_controller(ex)
 

--- a/fastlane_bot/helpers/txhelpers.py
+++ b/fastlane_bot/helpers/txhelpers.py
@@ -767,7 +767,7 @@ class TxHelpers:
                 return None
             try:
                 kwargs['gas_price'] = new_base_fee
-                transaction = contract_function(*args, **kwargs)
+                transaction = contract_function(*args).build_transaction(self.build_tx(**kwargs))
             except Exception as e:
                 self.ConfigObj.logger.warning(
                     f" Error when building transaction, this is expected to happen occasionally, discarding. (***1***)\n"


### PR DESCRIPTION
This fixes a critical error in the `build_transaction_generic` function. The `**kwargs` were mistakenly passed into the contract function instead of the `build_tx` function in cases in which the initial gas base fee was wrong, causing it to fail.

I have verified that transactions are able to be constructed after this change. 