### PR TITLE
Fix for _get_layer_one_gas_fee

### DIFF
--- a/fastlane_bot/helpers/txhelpers.py
+++ b/fastlane_bot/helpers/txhelpers.py
@@ -818,6 +818,6 @@ class TxHelpers:
         """
 
         l1_data_fee = asyncio.get_event_loop().run_until_complete(
-            asyncio.gather(self.ConfigObj.GAS_ORACLE_CONTRACT.caller.getL1Fee(raw_transaction)))
+            asyncio.gather(self.ConfigObj.GAS_ORACLE_CONTRACT.caller.getL1Fee(raw_transaction)))[0]
         # Dividing by 10 ** 18 in order to convert from wei resolution to native-token resolution
         return Decimal(f"{l1_data_fee}e-18")


### PR DESCRIPTION
In TxHelpers, the function `_get_layer_one_gas_fee` raises an error - ultimately due to trying to convert a List -> Decimal.

This is due to the async process returning a list - similar to what we saw in `run_blockchain_terraformer`.



