### PR TITLE
Clean ABIs following the removal of the factory address retrieval

### DIFF
--- a/fastlane_bot/data/abi.py
+++ b/fastlane_bot/data/abi.py
@@ -252,13 +252,6 @@ UNISWAP_V2_POOL_ABI = [
     },
     {
         "type": "function",
-        "name": "factory",
-        "stateMutability": "view",
-        "inputs": [],
-        "outputs": [{"internalType": "address", "name": "", "type": "address"}]
-    },
-    {
-        "type": "function",
         "name": "getReserves",
         "stateMutability": "view",
         "inputs": [],
@@ -286,13 +279,6 @@ UNISWAP_V3_POOL_ABI = [
         "name": "Swap",
         "anonymous": False,
         "inputs": [{"indexed": True, "internalType": "address", "name": "sender", "type": "address"}, {"indexed": True, "internalType": "address", "name": "recipient", "type": "address"}, {"indexed": False, "internalType": "int256", "name": "amount0", "type": "int256"}, {"indexed": False, "internalType": "int256", "name": "amount1", "type": "int256"}, {"indexed": False, "internalType": "uint160", "name": "sqrtPriceX96", "type": "uint160"}, {"indexed": False, "internalType": "uint128", "name": "liquidity", "type": "uint128"}, {"indexed": False, "internalType": "int24", "name": "tick", "type": "int24"}]
-    },
-    {
-        "type": "function",
-        "name": "factory",
-        "stateMutability": "view",
-        "inputs": [],
-        "outputs": [{"internalType": "address", "name": "", "type": "address"}]
     },
     {
         "type": "function",
@@ -347,13 +333,6 @@ PANCAKESWAP_V3_POOL_ABI = [
     },
     {
         "type": "function",
-        "name": "factory",
-        "stateMutability": "view",
-        "inputs": [],
-        "outputs": [{"internalType": "address", "name": "", "type": "address"}]
-    },
-    {
-        "type": "function",
         "name": "fee",
         "stateMutability": "view",
         "inputs": [],
@@ -405,13 +384,6 @@ SOLIDLY_V2_POOL_ABI = [
     },
     {
         "type": "function",
-        "name": "factory",
-        "stateMutability": "view",
-        "inputs": [],
-        "outputs": [{"internalType": "address", "name": "", "type": "address"}]
-    },
-    {
-        "type": "function",
         "name": "getReserves",
         "stateMutability": "view",
         "inputs": [],
@@ -434,50 +406,6 @@ SOLIDLY_V2_POOL_ABI = [
     {
         "type": "function",
         "name": "token1",
-        "stateMutability": "view",
-        "inputs": [],
-        "outputs": [{"internalType": "address", "name": "", "type": "address"}]
-    }
-]
-
-VELOCIMETER_V2_POOL_ABI = [
-    {
-        "type": "event",
-        "name": "Sync",
-        "anonymous": False,
-        "inputs": [{"indexed": False, "internalType": "uint256", "name": "reserve0", "type": "uint256"}, {"indexed": False, "internalType": "uint256", "name": "reserve1", "type": "uint256"}]
-    },
-    {
-        "type": "function",
-        "name": "getReserves",
-        "stateMutability": "view",
-        "inputs": [],
-        "outputs": [{"internalType": "uint256", "name": "_reserve0", "type": "uint256"}, {"internalType": "uint256", "name": "_reserve1", "type": "uint256"}, {"internalType": "uint256", "name": "_blockTimestampLast", "type": "uint256"}]
-    },
-    {
-        "type": "function",
-        "name": "stable",
-        "stateMutability": "view",
-        "inputs": [],
-        "outputs": [{"internalType": "bool", "name": "", "type": "bool"}]
-    },
-    {
-        "type": "function",
-        "name": "token0",
-        "stateMutability": "view",
-        "inputs": [],
-        "outputs": [{"internalType": "address", "name": "", "type": "address"}]
-    },
-    {
-        "type": "function",
-        "name": "token1",
-        "stateMutability": "view",
-        "inputs": [],
-        "outputs": [{"internalType": "address", "name": "", "type": "address"}]
-    },
-    {
-        "type": "function",
-        "name": "voter",
         "stateMutability": "view",
         "inputs": [],
         "outputs": [{"internalType": "address", "name": "", "type": "address"}]

--- a/fastlane_bot/events/exchanges/solidly_v2.py
+++ b/fastlane_bot/events/exchanges/solidly_v2.py
@@ -11,7 +11,7 @@ from typing import List, Type, Tuple, Any
 from web3.contract import Contract, AsyncContract
 
 from fastlane_bot.data.abi import SOLIDLY_V2_POOL_ABI, VELOCIMETER_V2_FACTORY_ABI, SOLIDLY_V2_FACTORY_ABI, \
-    VELOCIMETER_V2_POOL_ABI, SCALE_V2_FACTORY_ABI, CLEOPATRA_V2_FACTORY_ABI
+    SCALE_V2_FACTORY_ABI, CLEOPATRA_V2_FACTORY_ABI
 from fastlane_bot.events.exchanges.base import Exchange
 from fastlane_bot.events.pools.base import Pool
 
@@ -84,13 +84,13 @@ async def get_fee_4(address: str, contract: Contract, factory_contract: Contract
     return await factory_contract.caller.getPairFee(address, await contract.caller.stable())
 
 EXCHANGE_INFO = {
-    "velocimeter_v2": {"decimals": 4, "factory_abi": VELOCIMETER_V2_FACTORY_ABI, "pool_abi": VELOCIMETER_V2_POOL_ABI, "fee_function": get_fee_1},
-    "equalizer_v2": {"decimals": 4, "factory_abi": SCALE_V2_FACTORY_ABI, "pool_abi": SOLIDLY_V2_POOL_ABI, "fee_function": get_fee_2},
-    "aerodrome_v2": {"decimals": 4, "factory_abi": SOLIDLY_V2_FACTORY_ABI, "pool_abi": SOLIDLY_V2_POOL_ABI, "fee_function": get_fee_3},
-    "velodrome_v2": {"decimals": 4, "factory_abi": SOLIDLY_V2_FACTORY_ABI, "pool_abi": SOLIDLY_V2_POOL_ABI, "fee_function": get_fee_3},
-    "scale_v2": {"decimals": 18, "factory_abi": SCALE_V2_FACTORY_ABI, "pool_abi": SOLIDLY_V2_POOL_ABI, "fee_function": get_fee_2},
-    "cleopatra_v2": {"decimals": 4, "factory_abi": CLEOPATRA_V2_FACTORY_ABI, "pool_abi": SOLIDLY_V2_POOL_ABI, "fee_function": get_fee_4},
-    "stratum_v2": {"decimals": 4, "factory_abi": VELOCIMETER_V2_FACTORY_ABI, "pool_abi": VELOCIMETER_V2_POOL_ABI, "fee_function": get_fee_1},
+    "velocimeter_v2": {"decimals": 4, "factory_abi": VELOCIMETER_V2_FACTORY_ABI, "fee_function": get_fee_1},
+    "equalizer_v2": {"decimals": 4, "factory_abi": SCALE_V2_FACTORY_ABI, "fee_function": get_fee_2},
+    "aerodrome_v2": {"decimals": 4, "factory_abi": SOLIDLY_V2_FACTORY_ABI, "fee_function": get_fee_3},
+    "velodrome_v2": {"decimals": 4, "factory_abi": SOLIDLY_V2_FACTORY_ABI, "fee_function": get_fee_3},
+    "scale_v2": {"decimals": 18, "factory_abi": SCALE_V2_FACTORY_ABI, "fee_function": get_fee_2},
+    "cleopatra_v2": {"decimals": 4, "factory_abi": CLEOPATRA_V2_FACTORY_ABI, "fee_function": get_fee_4},
+    "stratum_v2": {"decimals": 4, "factory_abi": VELOCIMETER_V2_FACTORY_ABI, "fee_function": get_fee_1},
 }
 
 @dataclass
@@ -118,7 +118,7 @@ class SolidlyV2(Exchange):
         self.pools[pool.state["address"]] = pool
 
     def get_abi(self):
-        return EXCHANGE_INFO[self.exchange_name]["pool_abi"]
+        return SOLIDLY_V2_POOL_ABI
 
     @property
     def get_factory_abi(self):

--- a/fastlane_bot/tests/test_037_Exchanges.py
+++ b/fastlane_bot/tests/test_037_Exchanges.py
@@ -15,7 +15,7 @@ from fastlane_bot.events.exchanges.balancer import Balancer
 from fastlane_bot.tools.cpc import ConstantProductCurve as CPC
 from fastlane_bot.events.exchanges import UniswapV2, UniswapV3, CarbonV1, BancorV3, BancorV2, BancorPol, SolidlyV2
 from fastlane_bot.data.abi import UNISWAP_V2_POOL_ABI, UNISWAP_V3_POOL_ABI, BANCOR_V3_POOL_COLLECTION_ABI, \
-    CARBON_CONTROLLER_ABI, BANCOR_V2_CONVERTER_ABI, BANCOR_POL_ABI, BALANCER_VAULT_ABI, PANCAKESWAP_V3_POOL_ABI, VELOCIMETER_V2_POOL_ABI
+    CARBON_CONTROLLER_ABI, BANCOR_V2_CONVERTER_ABI, BANCOR_POL_ABI, BALANCER_VAULT_ABI, PANCAKESWAP_V3_POOL_ABI, SOLIDLY_V2_POOL_ABI
 
 from unittest.mock import Mock
 import nest_asyncio
@@ -96,7 +96,7 @@ def test_test_solidly_v2_exchange():
     
     @pytest.mark.asyncio
     async def test_solidly_v2_exchange():
-        assert (solidly_v2_exchange.get_abi() == VELOCIMETER_V2_POOL_ABI)
+        assert (solidly_v2_exchange.get_abi() == SOLIDLY_V2_POOL_ABI)
         #assert (await solidly_v2_exchange.get_fee('', mocked_contract) == ('0.003', 0.003)), f"{await solidly_v2_exchange.get_fee('', mocked_contract)}"
         assert (await solidly_v2_exchange.get_tkn0('', mocked_contract, None) == await mocked_contract.functions.token0().call())
         assert (solidly_v2_exchange.router_address == "jeffs_router")
@@ -121,7 +121,7 @@ def test_test_solidly_v2_exchange_fork():
     async def test_uniswap_v2_exchange():
         assert (velocimeter_v2_exchange.exchange_name in "velocimeter_v2"), f"Wrong exchange name. Expected velocimeter_v2, got {velocimeter_v2_exchange.exchange_name}"
         assert (velocimeter_v2_exchange.base_exchange_name in "solidly_v2"), f"Wrong base exchange name. Expected solidly_v2, got {velocimeter_v2_exchange.base_exchange_name}"    
-        assert (velocimeter_v2_exchange.get_abi() == VELOCIMETER_V2_POOL_ABI)
+        assert (velocimeter_v2_exchange.get_abi() == SOLIDLY_V2_POOL_ABI)
         #assert (await velocimeter_v2_exchange.get_fee('', mocked_contract) == ('0.0025', 0.0025)), f"{await velocimeter_v2_exchange.get_fee('', mocked_contract)}"
         assert (await velocimeter_v2_exchange.get_tkn0('', mocked_contract, None) == await mocked_contract.functions.token0().call())
         assert (velocimeter_v2_exchange.router_address == "jjs_router")


### PR DESCRIPTION
1. Remove functions `factory` and `voter` from pool contract ABIs
2. Remove the Velocimeter-V2 ABI and use the Solidly-V2 ABI instead