### PR TITLE
Convergence issues with overlapping strategies

### DIFF
--- a/fastlane_bot/helpers/poolandtokens.py
+++ b/fastlane_bot/helpers/poolandtokens.py
@@ -403,6 +403,14 @@ class PoolAndTokens:
         allow to omit yint (in which case it is set to y, but this does not make
         a difference for the result)
         """
+        def calculate_parameters(y: Decimal, pa: Decimal, pb: Decimal, pm: Decimal, n: Decimal):
+            H = pa.sqrt() ** n
+            L = pb.sqrt() ** n
+            M = pm.sqrt() ** n
+            A = H - L
+            B = L
+            z = y * (H - L) / (M - L) if M > L else y
+            return z
 
         # if idx == 0, use the first curve, otherwise use the second curve. change the numerical values to Decimal
         lst = []
@@ -523,14 +531,14 @@ class PoolAndTokens:
                 
                 # modify the y_int based on the new geomean to the limit of y    #TODO check that this math is correct
                 typed_args0 = strategy_typed_args[0]
-                new_yint0 = typed_args0['y'] * (typed_args0['pa'] - typed_args0['pb']) / ((1/geomean_p_marg) - typed_args0['pb'])  #this geomean is flipped because we flippend the pmarg from order 0
+                new_yint0 = calculate_parameters(y=typed_args0['y'], pa=typed_args0['pa'], pb=typed_args0['pb'], pm=(1/geomean_p_marg), n=1)
                 if new_yint0 < typed_args0['y']:
                     new_yint0 = typed_args0['y']
-                self.ConfigObj.logger.debug(f"[poolandtokens.py, _carbon_to_cpc] First order: typed_args0['yint'], new_yint0, , typed_args0['y']: {typed_args0['yint'], new_yint0, typed_args0['y']}")
+                self.ConfigObj.logger.debug(f"[poolandtokens.py, _carbon_to_cpc] First order: typed_args0['yint'], new_yint0, typed_args0['y']: {typed_args0['yint'], new_yint0, typed_args0['y']}")
                 typed_args0['yint'] = new_yint0
 
                 typed_args1 = strategy_typed_args[1]
-                new_yint1 = typed_args1['y'] * (typed_args1['pa'] - typed_args1['pb']) / (geomean_p_marg - typed_args1['pb'])
+                new_yint1 = calculate_parameters(y=typed_args1['y'], pa=typed_args1['pa'], pb=typed_args1['pb'], pm=(geomean_p_marg), n=1)
                 if new_yint1 < typed_args1['y']:
                     new_yint1 = typed_args1['y']
                 self.ConfigObj.logger.debug(f"[poolandtokens.py, _carbon_to_cpc] Second order: typed_args1['yint'], new_yint1, typed_args1['y']: {typed_args1['yint'], new_yint1, typed_args1['y']} \n")

--- a/fastlane_bot/helpers/poolandtokens.py
+++ b/fastlane_bot/helpers/poolandtokens.py
@@ -411,6 +411,12 @@ class PoolAndTokens:
             B = L
             z = y * (H - L) / (M - L) if M > L else y
             return z
+        
+        def check_overlap(pa0, pb0, pa1, pb1):
+            min0, max0 = sorted([pa0, pb0]) 
+            min1, max1 = sorted([1 / pa1, 1 / pb1]) 
+            prices_overlap = max(min0, min1) < min(max0, max1)
+            return prices_overlap 
 
         # if idx == 0, use the first curve, otherwise use the second curve. change the numerical values to Decimal
         lst = []
@@ -513,8 +519,7 @@ class PoolAndTokens:
             no_limit_orders = (strategy_typed_args[0]['is_limit_order'] == False) and (strategy_typed_args[1]['is_limit_order'] == False)
 
             # evaluate if the price boundaries pa/pb overlap at one end # TODO check logic and remove duplicate logic if necessary
-            prices_overlap = (strategy_typed_args[1]['pa']>(1/strategy_typed_args[0]['pa'])>strategy_typed_args[1]['pb']) # or (1/strategy_typed_args[0]['pa']<(strategy_typed_args[1]['pb']))
-            
+            prices_overlap = check_overlap(strategy_typed_args[0]['pa'], strategy_typed_args[0]['pb'], strategy_typed_args[1]['pa'], strategy_typed_args[1]['pb'])
             # if (percent_component_met and no_limit_orders) and not prices_overlap:
             #     print(percent_component_met, no_limit_orders, prices_overlap)
             #     print(strategy_typed_args)

--- a/fastlane_bot/utils.py
+++ b/fastlane_bot/utils.py
@@ -68,6 +68,10 @@ class EncodedOrder:
     def decodeFloat(cls, value):
         """undoes the mantisse/exponent encoding in A,B"""
         return (value % cls.ONE) << (value // cls.ONE)
+    
+    @classmethod
+    def decodeRate(cls, value):
+        return (value / cls.ONE) ** 2
 
     @classmethod
     def decode(cls, value):
@@ -179,15 +183,27 @@ class EncodedOrder:
     @property
     def p_marg(self):
         if self.y == self.z:
+            # try:
+            new_method = self.decodeRate(self.decodeFloat(int(self.B)) + self.decodeFloat(int(self.A)))
+            # except:
+            #     print(self.B, self.A)
+            #     print(type(self.B), type(self.A))
+            #     print(self.decodeFloat(int(self.B)) + self.decodeFloat(int(self.A)))
+            # print(new_method, self.p_start)
+            assert new_method == self.p_start, f"{new_method}, {self.p_start} **************************************"
             return self.p_start
         elif self.y == 0:
             return self.p_end
-        raise NotImplementedError("p_marg not implemented for non-full / empty orders")
-        A = self.decodeFloat(self.A)
-        B = self.decodeFloat(self.B)
-        return self.decode(B + A * self.y / self.z) ** 2
-        # https://github.com/bancorprotocol/carbon-simulator/blob/beta/benchmark/core/trade/impl.py
-        # 'marginalRate' : decodeRate(B + A if y == z else B + A * y / z),
+        # return 0
+        else:
+            return self.decodeRate(self.decodeFloat(int(self.B)) + (self.decodeFloat(int(self.A)) * self.y/self.z))
+
+        # raise NotImplementedError("p_marg not implemented for non-full / empty orders")
+        # A = self.decodeFloat(self.A)
+        # B = self.decodeFloat(self.B)
+        # return self.decode(B + A * self.y / self.z) ** 2
+        # # https://github.com/bancorprotocol/carbon-simulator/blob/beta/benchmark/core/trade/impl.py
+        # # 'marginalRate' : decodeRate(B + A if y == z else B + A * y / z),
 
 
 def find_latest_timestamped_folder(logging_path=None):

--- a/fastlane_bot/utils.py
+++ b/fastlane_bot/utils.py
@@ -182,29 +182,12 @@ class EncodedOrder:
 
     @property
     def p_marg(self):
+        A = self.decodeFloat(int(self.A))
+        B = self.decodeFloat(int(self.B))
         if self.y == self.z:
-            # try:
-            new_method = self.decodeRate(self.decodeFloat(int(self.B)) + self.decodeFloat(int(self.A)))
-            # except:
-            #     print(self.B, self.A)
-            #     print(type(self.B), type(self.A))
-            #     print(self.decodeFloat(int(self.B)) + self.decodeFloat(int(self.A)))
-            # print(new_method, self.p_start)
-            assert new_method == self.p_start, f"{new_method}, {self.p_start} **************************************"
-            return self.p_start
-        elif self.y == 0:
-            return self.p_end
-        # return 0
+            return self.decodeRate(B + A)
         else:
-            return self.decodeRate(self.decodeFloat(int(self.B)) + (self.decodeFloat(int(self.A)) * self.y/self.z))
-
-        # raise NotImplementedError("p_marg not implemented for non-full / empty orders")
-        # A = self.decodeFloat(self.A)
-        # B = self.decodeFloat(self.B)
-        # return self.decode(B + A * self.y / self.z) ** 2
-        # # https://github.com/bancorprotocol/carbon-simulator/blob/beta/benchmark/core/trade/impl.py
-        # # 'marginalRate' : decodeRate(B + A if y == z else B + A * y / z),
-
+            return self.decodeRate(B + A * self.y/self.z)
 
 def find_latest_timestamped_folder(logging_path=None):
     """


### PR DESCRIPTION
**MUST BE MERGE INTO #606 ASAP**

Overlapping strategies are designed to recreate Uniswap v3 like strategies on Carbon, ie ranges that trade bidirectional taking a small fee. Unsurprisingly -- in hindsight -- those strategies behave as badly within the Optimizer as other strategies with fees would (see #588). There is a reason that we ignore fees in the Optimizer and add them back only in the fine tuning step. 

High level the solution is actually pretty easy: **remove the effective fee component from overlapping strategies**. The current PR is designed to achieve that. However, it is a bit hacky, and once we have time we need to also take into account a few considerations spelled out in the next comment
