### PR TITLE
Fixing test 39 (silent fails of curve conversion)

### DIFF
--- a/fastlane_bot/tests/test_039_TestMultiMode.py
+++ b/fastlane_bot/tests/test_039_TestMultiMode.py
@@ -140,6 +140,7 @@ def test_test_tax_tokens():
 # ------------------------------------------------------------
     
     assert any(token.address in cfg.TAX_TOKENS for token in tokens), f"[TestMultiMode], DB does not include any tax tokens"
+    assert len(CCm) == 516, f"[NBTest 039 TestMultiMode] Expected 516 curves, found {len(CCm)}"
     
     for curve in CCm:
         for token in cfg.TAX_TOKENS:
@@ -178,6 +179,7 @@ def test_test_combos_and_tokens():
 # ------------------------------------------------------------
     
     # +
+    assert len(CCm) == 516, f"[NBTest 039 TestMultiMode] Expected 516 curves, found {len(CCm)}"
     arb_finder = bot._get_arb_finder("multi")
     finder = arb_finder(
                 flashloan_tokens=flashloan_tokens,
@@ -205,6 +207,7 @@ def test_test_expected_output():
 # ------------------------------------------------------------
     
     # +
+    assert len(CCm) == 516, f"[NBTest 039 TestMultiMode] Expected 516 curves, found {len(CCm)}"
     arb_finder = bot._get_arb_finder("multi")
     finder = arb_finder(
                 flashloan_tokens=flashloan_tokens,


### PR DESCRIPTION
Test 39 should assert the number of curves in the dataset to avoid silent conversion fails

(note this test will fail in PR #610)