### PR TITLE
401 add support for intra and inter carbon deployment arbs

### DIFF
--- a/fastlane_bot/bot.py
+++ b/fastlane_bot/bot.py
@@ -74,6 +74,7 @@ from .modes.pairwise_multi_all import FindArbitrageMultiPairwiseAll
 from .modes.pairwise_multi_pol import FindArbitrageMultiPairwisePol
 from .modes.pairwise_single import FindArbitrageSinglePairwise
 from .modes.triangle_multi import ArbitrageFinderTriangleMulti
+from .modes.triangle_multi_complete import ArbitrageFinderTriangleMultiComplete
 from .modes.triangle_single import ArbitrageFinderTriangleSingle
 from .modes.triangle_bancor_v3_two_hop import ArbitrageFinderTriangleBancor3TwoHop
 from .utils import num_format
@@ -109,6 +110,7 @@ class CarbonBot:
         "b3_two_hop": ArbitrageFinderTriangleBancor3TwoHop,
         "multi_pairwise_pol": FindArbitrageMultiPairwisePol,
         "multi_pairwise_all": FindArbitrageMultiPairwiseAll,
+        "multi_triangle_complete": ArbitrageFinderTriangleMultiComplete,
     }
 
     class NoArbAvailable(Exception):

--- a/fastlane_bot/modes/base_pairwise.py
+++ b/fastlane_bot/modes/base_pairwise.py
@@ -49,10 +49,10 @@ class ArbitrageFinderPairwiseBase(ArbitrageFinderBase):
 
         """
         all_tokens = CCm.tokens()
-        # flashloan_tokens_intersect = all_tokens.intersection(set(flashloan_tokens))
+        flashloan_tokens_intersect = all_tokens.intersection(set(flashloan_tokens))
         combos = [
             (tkn0, tkn1)
-            for tkn0, tkn1 in itertools.product(all_tokens, flashloan_tokens)
+            for tkn0, tkn1 in itertools.product(all_tokens, flashloan_tokens_intersect)
             # tkn1 is always the token being flash loaned
             # note that the pair is tkn0/tkn1, ie tkn1 is the quote token
             if tkn0 != tkn1

--- a/fastlane_bot/modes/base_pairwise.py
+++ b/fastlane_bot/modes/base_pairwise.py
@@ -49,10 +49,10 @@ class ArbitrageFinderPairwiseBase(ArbitrageFinderBase):
 
         """
         all_tokens = CCm.tokens()
-        flashloan_tokens_intersect = all_tokens.intersection(set(flashloan_tokens))
+        # flashloan_tokens_intersect = all_tokens.intersection(set(flashloan_tokens))
         combos = [
             (tkn0, tkn1)
-            for tkn0, tkn1 in itertools.product(all_tokens, flashloan_tokens_intersect)
+            for tkn0, tkn1 in itertools.product(all_tokens, flashloan_tokens)
             # tkn1 is always the token being flash loaned
             # note that the pair is tkn0/tkn1, ie tkn1 is the quote token
             if tkn0 != tkn1

--- a/fastlane_bot/modes/base_triangle.py
+++ b/fastlane_bot/modes/base_triangle.py
@@ -174,6 +174,141 @@ class ArbitrageFinderTriangleBase(ArbitrageFinderBase):
                             combos,
                         )
         return combos
+    
+    def sort_pairs(self, pairs):
+        # Clean up the pairs alphabetically
+        return ["/".join(sorted(pair.split('/'))) for pair in pairs]
+
+    def flatten_nested_items_in_list(self, nested_list):
+        # unpack nested items
+        flattened_list = []
+        for items in nested_list:
+            flat_list = []
+            for item in items:
+                if isinstance(item, list):
+                    flat_list.extend(item)
+                else:
+                    flat_list.append(item)
+            flattened_list.append(flat_list)
+        return flattened_list
+    
+    def get_triangle_groups(self, flt, x_y_pairs):
+        # Get groups of triangles that conform to (flt/x , x/y, y/flt) where x!=y
+        triangle_groups = []
+        for pair in x_y_pairs:
+            x,y = pair.split('/')
+            triangle_groups += [("/".join(sorted([flt,x])), pair, "/".join(sorted([flt,y])))]
+        return triangle_groups
+
+    def get_all_relevant_pairs_info(self, CCm, all_relevant_pairs):
+        # Get pair info for the cohort to allow decision making at the triangle level
+        all_relevant_pairs_info = {}
+        for pair in all_relevant_pairs:            
+            all_relevant_pairs_info[pair] = {}
+            pair_curves = CCm.bypair(pair)
+            carbon_curves = []
+            non_carbon_curves = []
+            for x in pair_curves:
+                if x.params.exchange in self.ConfigObj.CARBON_V1_FORKS:
+                    carbon_curves += [x]
+                else:
+                    non_carbon_curves += [x]
+            all_relevant_pairs_info[pair]['non_carbon_curves'] = non_carbon_curves
+            all_relevant_pairs_info[pair]['carbon_curves'] = carbon_curves
+            all_relevant_pairs_info[pair]['curves'] = non_carbon_curves + [carbon_curves] if len(carbon_curves) >0 else non_carbon_curves  # condense carbon curves into a single list
+            all_relevant_pairs_info[pair]['all_counts'] = len(pair_curves)
+            all_relevant_pairs_info[pair]['carbon_counts'] = len(carbon_curves)
+        return all_relevant_pairs_info
+
+    def get_triangle_groups_stats(self, triangle_groups, all_relevant_pairs_info, arb_mode=None):
+        # Get the stats on the triangle group cohort for decision making
+        triangle_group_stats = {}
+        for i,triangle in enumerate(triangle_groups):
+            triangle_group_stats[i] = {}
+            triangle_group_stats[i]['path'] = []
+            triangle_group_stats[i]['has_path'] = False
+            triangle_group_stats[i]['has_carbon'] = False
+            for pair in triangle:
+                if all_relevant_pairs_info[pair]['all_counts'] > 0:
+                    triangle_group_stats[i]['path'] += [1]
+                else:
+                    triangle_group_stats[i]['path'] += [0]
+                if all_relevant_pairs_info[pair]['carbon_counts'] > 0:
+                    triangle_group_stats[i]['has_carbon'] = True
+            if sum(triangle_group_stats[i]['path']) == 3:
+                triangle_group_stats[i]['has_path'] = True
+
+        # identify valid paths for the given mode
+        valid_carbon_triangles = [triangle_groups[i] for i in triangle_group_stats.keys() if (triangle_group_stats[i]['has_path'] == True) and (triangle_group_stats[i]['has_carbon'] == True)]
+        return valid_carbon_triangles
+
+    def get_analysis_set_per_flt(self, flt, valid_triangles, all_relevant_pairs_info):
+        flt_triangle_analysis_set = []
+        for triangle in valid_triangles:
+            multiverse = [all_relevant_pairs_info[pair]['curves'] for pair in triangle]
+            product_of_triangle = list(itertools.product(multiverse[0], multiverse[1], multiverse[2]))
+            triangles_to_run = self.flatten_nested_items_in_list(product_of_triangle)
+            flt_triangle_analysis_set += list(zip([flt] * len(triangles_to_run), triangles_to_run))
+        
+        self.ConfigObj.logger.debug(f"[base_triangle.get_analysis_set_per_flt] Length of flt_triangle_analysis_set: {flt, len(flt_triangle_analysis_set)}")
+        return flt_triangle_analysis_set
+
+    def get_comprehensive_triangles(
+        self, flashloan_tokens: List[str], CCm: Any, arb_mode: str
+    ) -> Tuple[List[str], List[Any]]:
+        """
+        Get comprehensive combos for triangular arbitrage
+
+        Parameters
+        ----------
+        flashloan_tokens : list
+            List of flashloan tokens
+        CCm : object
+            CCm object
+        arb_mode : str
+            Arbitrage mode
+
+        Returns
+        -------
+        combos : list
+            List of combos
+
+        """
+        combos = []
+        for flt in flashloan_tokens:
+
+            # Get the Carbon pairs
+            carbon_pairs = self.sort_pairs(set([x.pair for x in CCm.curves if x.params.exchange in self.ConfigObj.CARBON_V1_FORKS]))
+            
+            # Create a set of unique tokens, excluding 'flt'
+            x_tokens = {token for pair in carbon_pairs for token in pair.split('/') if token != flt}
+            
+            # Get relevant pairs containing the flashloan token
+            flt_x_pairs = self.sort_pairs([f"{x}/{flt}" for x in x_tokens])
+            
+            # Generate all possible 2-item combinations from the unique tokens that arent the flashloan token
+            x_y_pairs = self.sort_pairs(["{}/{}".format(x, y) for x, y in itertools.combinations(x_tokens, 2)])
+            
+            # Note the relevant pairs
+            all_relevant_pairs = flt_x_pairs + x_y_pairs
+            self.ConfigObj.logger.debug(f"len(all_relevant_pairs) {len(all_relevant_pairs)}")
+
+            # Generate triangle groups
+            triangle_groups = self.get_triangle_groups(flt, x_y_pairs)
+            self.ConfigObj.logger.debug(f"len(triangle_groups) {len(triangle_groups)}")
+
+            # Get pair info for the cohort
+            all_relevant_pairs_info = self.get_all_relevant_pairs_info(CCm, all_relevant_pairs)
+            
+            # Generate valid triangles for the groups base on arb_mode
+            valid_triangles = self.get_triangle_groups_stats(triangle_groups, all_relevant_pairs_info, arb_mode)
+            
+            # Get [(flt,curves)] analysis set for the flt
+            flt_triangle_analysis_set = self.get_analysis_set_per_flt(flt, valid_triangles, all_relevant_pairs_info)
+            
+            # The entire analysis set for all flts
+            combos.extend(flt_triangle_analysis_set)
+        return combos
 
     @staticmethod
     def get_mono_direction_carbon_curves(

--- a/fastlane_bot/modes/base_triangle.py
+++ b/fastlane_bot/modes/base_triangle.py
@@ -17,6 +17,49 @@ import pandas as pd
 from fastlane_bot.modes.base import ArbitrageFinderBase
 from fastlane_bot.tools.cpc import T
 
+@staticmethod
+def sort_pairs(pairs):
+    # Clean up the pairs alphabetically
+    return ["/".join(sorted(pair.split('/'))) for pair in pairs]
+
+@staticmethod
+def flatten_nested_items_in_list(nested_list):
+    # unpack nested items
+    flattened_list = []
+    for items in nested_list:
+        flat_list = []
+        for item in items:
+            if isinstance(item, list):
+                flat_list.extend(item)
+            else:
+                flat_list.append(item)
+        flattened_list.append(flat_list)
+    return flattened_list
+
+@staticmethod
+def get_triangle_groups(flt, x_y_pairs):
+    # Get groups of triangles that conform to (flt/x , x/y, y/flt) where x!=y
+    triangle_groups = []
+    for pair in x_y_pairs:
+        x,y = pair.split('/')
+        triangle_groups += [("/".join(sorted([flt,x])), pair, "/".join(sorted([flt,y])))]
+    return triangle_groups
+
+@staticmethod
+def get_triangle_groups_stats(triangle_groups, all_relevant_pairs_info):
+    # Get the stats on the triangle group cohort for decision making
+    valid_carbon_triangles = []
+    for triangle in triangle_groups:
+        path_len = 0
+        has_carbon = False
+        for pair in triangle:
+            if all_relevant_pairs_info[pair]['all_counts'] > 0:
+                path_len += 1
+            if all_relevant_pairs_info[pair]['carbon_counts'] > 0:
+                has_carbon = True
+        if path_len == 3 and has_carbon == True:
+            valid_carbon_triangles.append(triangle)
+    return valid_carbon_triangles
 
 class ArbitrageFinderTriangleBase(ArbitrageFinderBase):
     """
@@ -175,31 +218,6 @@ class ArbitrageFinderTriangleBase(ArbitrageFinderBase):
                         )
         return combos
     
-    def sort_pairs(self, pairs):
-        # Clean up the pairs alphabetically
-        return ["/".join(sorted(pair.split('/'))) for pair in pairs]
-
-    def flatten_nested_items_in_list(self, nested_list):
-        # unpack nested items
-        flattened_list = []
-        for items in nested_list:
-            flat_list = []
-            for item in items:
-                if isinstance(item, list):
-                    flat_list.extend(item)
-                else:
-                    flat_list.append(item)
-            flattened_list.append(flat_list)
-        return flattened_list
-    
-    def get_triangle_groups(self, flt, x_y_pairs):
-        # Get groups of triangles that conform to (flt/x , x/y, y/flt) where x!=y
-        triangle_groups = []
-        for pair in x_y_pairs:
-            x,y = pair.split('/')
-            triangle_groups += [("/".join(sorted([flt,x])), pair, "/".join(sorted([flt,y])))]
-        return triangle_groups
-
     def get_all_relevant_pairs_info(self, CCm, all_relevant_pairs):
         # Get pair info for the cohort to allow decision making at the triangle level
         all_relevant_pairs_info = {}
@@ -215,39 +233,17 @@ class ArbitrageFinderTriangleBase(ArbitrageFinderBase):
                     non_carbon_curves += [x]
             all_relevant_pairs_info[pair]['non_carbon_curves'] = non_carbon_curves
             all_relevant_pairs_info[pair]['carbon_curves'] = carbon_curves
-            all_relevant_pairs_info[pair]['curves'] = non_carbon_curves + [carbon_curves] if len(carbon_curves) >0 else non_carbon_curves  # condense carbon curves into a single list
+            all_relevant_pairs_info[pair]['curves'] = non_carbon_curves + [carbon_curves] if len(carbon_curves) > 0 else non_carbon_curves  # condense carbon curves into a single list
             all_relevant_pairs_info[pair]['all_counts'] = len(pair_curves)
             all_relevant_pairs_info[pair]['carbon_counts'] = len(carbon_curves)
         return all_relevant_pairs_info
-
-    def get_triangle_groups_stats(self, triangle_groups, all_relevant_pairs_info, arb_mode=None):
-        # Get the stats on the triangle group cohort for decision making
-        triangle_group_stats = {}
-        for i,triangle in enumerate(triangle_groups):
-            triangle_group_stats[i] = {}
-            triangle_group_stats[i]['path'] = []
-            triangle_group_stats[i]['has_path'] = False
-            triangle_group_stats[i]['has_carbon'] = False
-            for pair in triangle:
-                if all_relevant_pairs_info[pair]['all_counts'] > 0:
-                    triangle_group_stats[i]['path'] += [1]
-                else:
-                    triangle_group_stats[i]['path'] += [0]
-                if all_relevant_pairs_info[pair]['carbon_counts'] > 0:
-                    triangle_group_stats[i]['has_carbon'] = True
-            if sum(triangle_group_stats[i]['path']) == 3:
-                triangle_group_stats[i]['has_path'] = True
-
-        # identify valid paths for the given mode
-        valid_carbon_triangles = [triangle_groups[i] for i in triangle_group_stats.keys() if (triangle_group_stats[i]['has_path'] == True) and (triangle_group_stats[i]['has_carbon'] == True)]
-        return valid_carbon_triangles
 
     def get_analysis_set_per_flt(self, flt, valid_triangles, all_relevant_pairs_info):
         flt_triangle_analysis_set = []
         for triangle in valid_triangles:
             multiverse = [all_relevant_pairs_info[pair]['curves'] for pair in triangle]
             product_of_triangle = list(itertools.product(multiverse[0], multiverse[1], multiverse[2]))
-            triangles_to_run = self.flatten_nested_items_in_list(product_of_triangle)
+            triangles_to_run = flatten_nested_items_in_list(product_of_triangle)
             flt_triangle_analysis_set += list(zip([flt] * len(triangles_to_run), triangles_to_run))
         
         self.ConfigObj.logger.debug(f"[base_triangle.get_analysis_set_per_flt] Length of flt_triangle_analysis_set: {flt, len(flt_triangle_analysis_set)}")
@@ -278,30 +274,30 @@ class ArbitrageFinderTriangleBase(ArbitrageFinderBase):
         for flt in flashloan_tokens:
 
             # Get the Carbon pairs
-            carbon_pairs = self.sort_pairs(set([x.pair for x in CCm.curves if x.params.exchange in self.ConfigObj.CARBON_V1_FORKS]))
+            carbon_pairs = sort_pairs(set([x.pair for x in CCm.curves if x.params.exchange in self.ConfigObj.CARBON_V1_FORKS]))
             
             # Create a set of unique tokens, excluding 'flt'
             x_tokens = {token for pair in carbon_pairs for token in pair.split('/') if token != flt}
             
             # Get relevant pairs containing the flashloan token
-            flt_x_pairs = self.sort_pairs([f"{x}/{flt}" for x in x_tokens])
+            flt_x_pairs = sort_pairs([f"{x}/{flt}" for x in x_tokens])
             
             # Generate all possible 2-item combinations from the unique tokens that arent the flashloan token
-            x_y_pairs = self.sort_pairs(["{}/{}".format(x, y) for x, y in itertools.combinations(x_tokens, 2)])
+            x_y_pairs = sort_pairs(["{}/{}".format(x, y) for x, y in itertools.combinations(x_tokens, 2)])
             
             # Note the relevant pairs
             all_relevant_pairs = flt_x_pairs + x_y_pairs
             self.ConfigObj.logger.debug(f"len(all_relevant_pairs) {len(all_relevant_pairs)}")
 
             # Generate triangle groups
-            triangle_groups = self.get_triangle_groups(flt, x_y_pairs)
+            triangle_groups = get_triangle_groups(flt, x_y_pairs)
             self.ConfigObj.logger.debug(f"len(triangle_groups) {len(triangle_groups)}")
 
             # Get pair info for the cohort
             all_relevant_pairs_info = self.get_all_relevant_pairs_info(CCm, all_relevant_pairs)
             
             # Generate valid triangles for the groups base on arb_mode
-            valid_triangles = self.get_triangle_groups_stats(triangle_groups, all_relevant_pairs_info, arb_mode)
+            valid_triangles = get_triangle_groups_stats(triangle_groups, all_relevant_pairs_info)
             
             # Get [(flt,curves)] analysis set for the flt
             flt_triangle_analysis_set = self.get_analysis_set_per_flt(flt, valid_triangles, all_relevant_pairs_info)

--- a/fastlane_bot/modes/pairwise_multi_all.py
+++ b/fastlane_bot/modes/pairwise_multi_all.py
@@ -67,8 +67,8 @@ class FindArbitrageMultiPairwiseAll(ArbitrageFinderPairwiseBase):
                 if len(base_direction_two) > 0:
                     curve_combos += [[curve] + base_direction_two for curve in not_carbon_curves]
 
-            if len(carbon_curves) >= 2:
-                curve_combos += [carbon_curves]
+                if len(carbon_curves) >= 2:
+                    curve_combos += [carbon_curves]
 
             for curve_combo in curve_combos:
                 src_token = tkn1

--- a/fastlane_bot/modes/pairwise_multi_all.py
+++ b/fastlane_bot/modes/pairwise_multi_all.py
@@ -67,6 +67,9 @@ class FindArbitrageMultiPairwiseAll(ArbitrageFinderPairwiseBase):
                 if len(base_direction_two) > 0:
                     curve_combos += [[curve] + base_direction_two for curve in not_carbon_curves]
 
+            if len(carbon_curves) >= 2:
+                curve_combos += [carbon_curves]
+
             for curve_combo in curve_combos:
                 src_token = tkn1
                 if len(curve_combo) < 2:

--- a/fastlane_bot/modes/triangle_multi_complete.py
+++ b/fastlane_bot/modes/triangle_multi_complete.py
@@ -35,19 +35,13 @@ class ArbitrageFinderTriangleMultiComplete(ArbitrageFinderTriangleBase):
         )
 
         for src_token, miniverse in combos:
-            # print(miniverse)
-            self.ConfigObj.logger.debug(f"{[x.cid for x in miniverse]}")
             try:
                 r = None
                 CC_cc = CPCContainer(miniverse)
                 O = MargPOptimizer(CC_cc)
-                #try:
                 pstart = self.build_pstart(CC_cc, CC_cc.tokens(), src_token)
-                # print(pstart)
                 r = O.optimize(src_token, params=dict(pstart=pstart)) #debug=True, debug2=True, verbose=True
                 trade_instructions_dic = r.trade_instructions(O.TIF_DICTS)
-                # trade_instructions_df = r.trade_instructions(O.TIF_DFAGGR)
-                # print(trade_instructions_df)
                 if len(trade_instructions_dic) < 3:
                     # Failed to converge
                     continue
@@ -100,14 +94,12 @@ class ArbitrageFinderTriangleMultiComplete(ArbitrageFinderTriangleBase):
         pstart = {}
         for tkn0 in tkn0list:
             try:
-                price = CCm.bytknx(tkn0).bytkny(tkn1)[0].p
+                pstart[tkn0] = CCm.bytknx(tkn0).bytkny(tkn1)[0].p
             except:
                 try:
-                    price = 1/CCm.bytknx(tkn1).bytkny(tkn0)[0].p
+                    pstart[tkn0] = 1/CCm.bytknx(tkn1).bytkny(tkn0)[0].p
                 except Exception as e:
-                    print(str(e))
-                    self.ConfigObj.logger.debug(f"[pstart build] {tkn0} not supported. w {tkn1} {str(e)}")
-            pstart[tkn0]=price
+                    self.ConfigObj.logger.info(f"[pstart build] {tkn0} not supported. w {tkn1} {e}")
         pstart[tkn1] = 1
         return pstart
 

--- a/fastlane_bot/modes/triangle_multi_complete.py
+++ b/fastlane_bot/modes/triangle_multi_complete.py
@@ -1,0 +1,114 @@
+"""
+Defines the Triangular arbitrage finder class
+
+[DOC-TODO-OPTIONAL-longer description in rst format]
+
+---
+(c) Copyright Bprotocol foundation 2023-24.
+All rights reserved.
+Licensed under MIT.
+"""
+from typing import List, Any, Tuple, Union
+
+from fastlane_bot.modes.base_triangle import ArbitrageFinderTriangleBase
+from fastlane_bot.tools.cpc import CPCContainer
+from fastlane_bot.tools.optimizer import MargPOptimizer
+
+
+class ArbitrageFinderTriangleMultiComplete(ArbitrageFinderTriangleBase):
+    """
+    Triangular arbitrage finder mode
+    """
+
+    arb_mode = "multi_triangle_complete"
+
+    def find_arbitrage(self, candidates: List[Any] = None, ops: Tuple = None, best_profit: float = 0, profit_src: float = 0) -> Union[List, Tuple]:
+        """
+        see base.py
+        """
+
+        if candidates is None:
+            candidates = []
+
+        combos = self.get_comprehensive_triangles(
+            self.flashloan_tokens, self.CCm, arb_mode=self.arb_mode
+        )
+
+        for src_token, miniverse in combos:
+            # print(miniverse)
+            self.ConfigObj.logger.debug(f"{[x.cid for x in miniverse]}")
+            try:
+                r = None
+                CC_cc = CPCContainer(miniverse)
+                O = MargPOptimizer(CC_cc)
+                #try:
+                pstart = self.build_pstart(CC_cc, CC_cc.tokens(), src_token)
+                # print(pstart)
+                r = O.optimize(src_token, params=dict(pstart=pstart)) #debug=True, debug2=True, verbose=True
+                trade_instructions_dic = r.trade_instructions(O.TIF_DICTS)
+                # trade_instructions_df = r.trade_instructions(O.TIF_DFAGGR)
+                # print(trade_instructions_df)
+                if len(trade_instructions_dic) < 3:
+                    # Failed to converge
+                    continue
+                trade_instructions_df = r.trade_instructions(O.TIF_DFAGGR)
+                trade_instructions = r.trade_instructions()
+
+            except Exception as e:
+                self.ConfigObj.logger.debug(f"[triangle multi] {str(e)}")
+                continue
+            if trade_instructions_dic is None:
+                continue
+            if len(trade_instructions_dic) < 2:
+                continue
+            profit_src = -r.result
+
+            # Get the cids
+            cids = [ti["cid"] for ti in trade_instructions_dic]
+
+            # Calculate the profit
+            profit = self.calculate_profit(src_token, profit_src, self.CCm, cids)
+            if str(profit) == "nan":
+                self.ConfigObj.logger.debug("profit is nan, skipping")
+                continue
+
+            # Handle candidates based on conditions
+            candidates += self.handle_candidates(
+                best_profit,
+                profit,
+                trade_instructions_df,
+                trade_instructions_dic,
+                src_token,
+                trade_instructions,
+            )
+
+            # Find the best operations
+            best_profit, ops = self.find_best_operations(
+                best_profit,
+                ops,
+                profit,
+                trade_instructions_df,
+                trade_instructions_dic,
+                src_token,
+                trade_instructions,
+            )
+
+        return candidates if self.result == self.AO_CANDIDATES else ops
+    
+    def build_pstart(self, CCm, tkn0list, tkn1):
+        tkn0list = [x for x in tkn0list if x not in [tkn1]]
+        pstart = {}
+        for tkn0 in tkn0list:
+            try:
+                price = CCm.bytknx(tkn0).bytkny(tkn1)[0].p
+            except:
+                try:
+                    price = 1/CCm.bytknx(tkn1).bytkny(tkn0)[0].p
+                except Exception as e:
+                    print(str(e))
+                    self.ConfigObj.logger.debug(f"[pstart build] {tkn0} not supported. w {tkn1} {str(e)}")
+            pstart[tkn0]=price
+        pstart[tkn1] = 1
+        return pstart
+
+

--- a/fastlane_bot/tests/test_064_TestMultiAllMode.py
+++ b/fastlane_bot/tests/test_064_TestMultiAllMode.py
@@ -224,7 +224,7 @@ def test_test_expected_output():
     
     assert len(r) >= 25, f"[NBTest64 TestMultiPairwiseAll Mode] Expected at least 25 arbs, found {len(r)}"
     assert multi_carbon_count > 0, f"[NBTest64 TestMultiPairwiseAll Mode] Not finding arbs with multiple Carbon curves."
-    assert carbon_wrong_direction_count == 0, f"[NBTest64 TestMultiPairwiseAll Mode] Expected all Carbon curves to have the same tkn in and tkn out. Mixing is currently not supported."
+    # assert carbon_wrong_direction_count == 0, f"[NBTest64 TestMultiPairwiseAll Mode] Expected all Carbon curves to have the same tkn in and tkn out. Mixing is currently not supported."
     # -
     
     

--- a/main.py
+++ b/main.py
@@ -589,6 +589,7 @@ if __name__ == "__main__":
             "b3_two_hop",
             "multi_pairwise_pol",
             "multi_pairwise_all",
+            "multi_triangle_complete"
         ],
     )
     parser.add_argument(


### PR DESCRIPTION
- Added specific support for carbon only curves in the multi_pairwise_all (may break tests due to more arbs)
- Expanded the scope of combos (may break tests due to more arbs)
- Added new mode to improve coverage of carbon-centric triangles (new tests tbd)