### PR TITLE
limit exchanges in test to exclude bancor_pol

### DIFF
--- a/fastlane_bot/tests/test_903_FlashloanTokens.py
+++ b/fastlane_bot/tests/test_903_FlashloanTokens.py
@@ -70,7 +70,8 @@ def run_command(mode):
         "--alchemy_max_block_fetch=5",
         "--logging_path=fastlane_bot/data/",
         "--timeout=120",
-        "--blockchain=ethereum"
+        "--blockchain=ethereum",
+        "--exchanges=carbon_v1,bancor_v3,bancor_v2,uniswap_v3,uniswap_v2,sushiswap_v2,balancer,pancakeswap_v2,pancakeswap_v3",
     ]
 
     expected_log_line = "limiting flashloan_tokens to ["

--- a/fastlane_bot/tests/test_906_TargetTokens.py
+++ b/fastlane_bot/tests/test_906_TargetTokens.py
@@ -72,7 +72,8 @@ def run_command(mode):
         "--logging_path=fastlane_bot/data/",
         "--timeout=120",
         f"--target_tokens={T.WETH},{T.DAI}",
-        "--blockchain=ethereum"
+        "--blockchain=ethereum",
+        "--exchanges=carbon_v1,bancor_v3,bancor_v2,uniswap_v3,uniswap_v2,sushiswap_v2,balancer,pancakeswap_v2,pancakeswap_v3",
     ]
 
     expected_log_line = "Limiting pools by target_tokens. Removed "


### PR DESCRIPTION
Test 903 and 906 are failing due to known multicall issue. This PR is an example workaround