### PR TITLE
Fix several issue in the triangle-mode implementation

### DIFF
--- a/fastlane_bot/modes/base_triangle.py
+++ b/fastlane_bot/modes/base_triangle.py
@@ -17,12 +17,10 @@ import pandas as pd
 from fastlane_bot.modes.base import ArbitrageFinderBase
 from fastlane_bot.tools.cpc import T
 
-@staticmethod
 def sort_pairs(pairs):
     # Clean up the pairs alphabetically
     return ["/".join(sorted(pair.split('/'))) for pair in pairs]
 
-@staticmethod
 def flatten_nested_items_in_list(nested_list):
     # unpack nested items
     flattened_list = []
@@ -36,7 +34,6 @@ def flatten_nested_items_in_list(nested_list):
         flattened_list.append(flat_list)
     return flattened_list
 
-@staticmethod
 def get_triangle_groups(flt, x_y_pairs):
     # Get groups of triangles that conform to (flt/x , x/y, y/flt) where x!=y
     triangle_groups = []
@@ -45,7 +42,6 @@ def get_triangle_groups(flt, x_y_pairs):
         triangle_groups += [("/".join(sorted([flt,x])), pair, "/".join(sorted([flt,y])))]
     return triangle_groups
 
-@staticmethod
 def get_triangle_groups_stats(triangle_groups, all_relevant_pairs_info):
     # Get the stats on the triangle group cohort for decision making
     valid_carbon_triangles = []
@@ -250,7 +246,7 @@ class ArbitrageFinderTriangleBase(ArbitrageFinderBase):
         return flt_triangle_analysis_set
 
     def get_comprehensive_triangles(
-        self, flashloan_tokens: List[str], CCm: Any, arb_mode: str
+        self, flashloan_tokens: List[str], CCm: Any
     ) -> Tuple[List[str], List[Any]]:
         """
         Get comprehensive combos for triangular arbitrage
@@ -261,8 +257,6 @@ class ArbitrageFinderTriangleBase(ArbitrageFinderBase):
             List of flashloan tokens
         CCm : object
             CCm object
-        arb_mode : str
-            Arbitrage mode
 
         Returns
         -------

--- a/fastlane_bot/modes/base_triangle.py
+++ b/fastlane_bot/modes/base_triangle.py
@@ -345,18 +345,17 @@ class ArbitrageFinderTriangleBase(ArbitrageFinderBase):
                 wrong_direction_cids.append(idx)
 
         return [curve for curve in miniverse if curve.cid not in wrong_direction_cids]
+
     def build_pstart(self, CCm, tkn0list, tkn1):
         tkn0list = [x for x in tkn0list if x not in [tkn1]]
         pstart = {}
         for tkn0 in tkn0list:
             try:
-                price = CCm.bytknx(tkn0).bytkny(tkn1)[0].p
+                pstart[tkn0] = CCm.bytknx(tkn0).bytkny(tkn1)[0].p
             except:
                 try:
-                    price = 1/CCm.bytknx(tkn1).bytkny(tkn0)[0].p
+                    pstart[tkn0] = 1/CCm.bytknx(tkn1).bytkny(tkn0)[0].p
                 except Exception as e:
-                    print(str(e))
-                    self.ConfigObj.logger.debug(f"[pstart build] {tkn0} not supported. w {tkn1} {str(e)}")
-            pstart[tkn0]=price
+                    self.ConfigObj.logger.info(f"[pstart build] {tkn0}/{tkn1} price error {e}")
         pstart[tkn1] = 1
         return pstart

--- a/fastlane_bot/modes/base_triangle.py
+++ b/fastlane_bot/modes/base_triangle.py
@@ -300,52 +300,6 @@ class ArbitrageFinderTriangleBase(ArbitrageFinderBase):
             combos.extend(flt_triangle_analysis_set)
         return combos
 
-    @staticmethod
-    def get_mono_direction_carbon_curves(
-        miniverse: List[Any], trade_instructions_df: pd.DataFrame, token_in: str=None
-    ) -> List[Any]:
-        """
-        Get mono direction carbon curves for triangular arbitrage
-
-        Parameters
-        ----------
-        miniverse : list
-            List of miniverses
-        token_in : str
-            Token in
-        trade_instructions_df : DataFrame
-            Trade instructions dataframe
-
-        Returns
-        -------
-        mono_direction_carbon_curves : list
-            List of mono direction carbon curves
-
-        """
-
-        if token_in is None:
-            columns = trade_instructions_df.columns
-            check_nan = trade_instructions_df.copy().fillna(0)
-            first_bancor_v3_pool = check_nan.iloc[0]
-            second_bancor_v3_pool = check_nan.iloc[1]
-
-            for idx, token in enumerate(columns):
-                if token == T.BNT:
-                    continue
-                if first_bancor_v3_pool[token] < 0:
-                    token_in = token
-                    break
-                if second_bancor_v3_pool[token] < 0:
-                    token_in = token
-                    break
-
-        wrong_direction_cids = []
-        for idx, row in trade_instructions_df.iterrows():
-            if (row[token_in] < 0) and ("-0" in idx or "-1" in idx):
-                wrong_direction_cids.append(idx)
-
-        return [curve for curve in miniverse if curve.cid not in wrong_direction_cids]
-
     def build_pstart(self, CCm, tkn0list, tkn1):
         tkn0list = [x for x in tkn0list if x not in [tkn1]]
         pstart = {}

--- a/fastlane_bot/modes/triangle_multi.py
+++ b/fastlane_bot/modes/triangle_multi.py
@@ -42,22 +42,17 @@ class ArbitrageFinderTriangleMulti(ArbitrageFinderTriangleBase):
                 r = None
                 CC_cc = CPCContainer(miniverse)
                 O = MargPOptimizer(CC_cc)
-                #try:
                 pstart = self.build_pstart(CC_cc, CC_cc.tokens(), src_token)
                 r = O.optimize(src_token, params=dict(pstart=pstart)) #debug=True, debug2=True
                 trade_instructions_dic = r.trade_instructions(O.TIF_DICTS)
-                if len(trade_instructions_dic) < 3:
+                if trade_instructions_dic is None or len(trade_instructions_dic) < 3:
                     # Failed to converge
                     continue
                 trade_instructions_df = r.trade_instructions(O.TIF_DFAGGR)
                 trade_instructions = r.trade_instructions()
 
             except Exception as e:
-                self.ConfigObj.logger.debug(f"[triangle multi] {str(e)}")
-                continue
-            if trade_instructions_dic is None:
-                continue
-            if len(trade_instructions_dic) < 2:
+                self.ConfigObj.logger.info(f"[triangle multi] {e}")
                 continue
             profit_src = -r.result
 

--- a/fastlane_bot/modes/triangle_multi.py
+++ b/fastlane_bot/modes/triangle_multi.py
@@ -92,21 +92,3 @@ class ArbitrageFinderTriangleMulti(ArbitrageFinderTriangleBase):
             )
 
         return candidates if self.result == self.AO_CANDIDATES else ops
-    
-    def build_pstart(self, CCm, tkn0list, tkn1):
-        tkn0list = [x for x in tkn0list if x not in [tkn1]]
-        pstart = {}
-        for tkn0 in tkn0list:
-            try:
-                price = CCm.bytknx(tkn0).bytkny(tkn1)[0].p
-            except:
-                try:
-                    price = 1/CCm.bytknx(tkn1).bytkny(tkn0)[0].p
-                except Exception as e:
-                    print(str(e))
-                    self.ConfigObj.logger.debug(f"[pstart build] {tkn0} not supported. w {tkn1} {str(e)}")
-            pstart[tkn0]=price
-        pstart[tkn1] = 1
-        return pstart
-
-

--- a/fastlane_bot/modes/triangle_multi.py
+++ b/fastlane_bot/modes/triangle_multi.py
@@ -39,7 +39,6 @@ class ArbitrageFinderTriangleMulti(ArbitrageFinderTriangleBase):
 
         for src_token, miniverse in combos:
             try:
-                r = None
                 CC_cc = CPCContainer(miniverse)
                 O = MargPOptimizer(CC_cc)
                 pstart = self.build_pstart(CC_cc, CC_cc.tokens(), src_token)

--- a/fastlane_bot/modes/triangle_multi.py
+++ b/fastlane_bot/modes/triangle_multi.py
@@ -33,16 +33,14 @@ class ArbitrageFinderTriangleMulti(ArbitrageFinderTriangleBase):
         if candidates is None:
             candidates = []
 
-        combos = self.get_combos(
-            self.flashloan_tokens, self.CCm, arb_mode=self.arb_mode
-        )
+        combos = self.get_combos(self.flashloan_tokens, self.CCm, arb_mode=self.arb_mode)
 
         for src_token, miniverse in combos:
             try:
                 CC_cc = CPCContainer(miniverse)
                 O = MargPOptimizer(CC_cc)
                 pstart = self.build_pstart(CC_cc, CC_cc.tokens(), src_token)
-                r = O.optimize(src_token, params=dict(pstart=pstart)) #debug=True, debug2=True
+                r = O.optimize(src_token, params=dict(pstart=pstart))
                 trade_instructions_dic = r.trade_instructions(O.TIF_DICTS)
                 if trade_instructions_dic is None or len(trade_instructions_dic) < 3:
                     # Failed to converge

--- a/fastlane_bot/modes/triangle_multi_complete.py
+++ b/fastlane_bot/modes/triangle_multi_complete.py
@@ -81,19 +81,3 @@ class ArbitrageFinderTriangleMultiComplete(ArbitrageFinderTriangleBase):
             )
 
         return candidates if self.result == self.AO_CANDIDATES else ops
-    
-    def build_pstart(self, CCm, tkn0list, tkn1):
-        tkn0list = [x for x in tkn0list if x not in [tkn1]]
-        pstart = {}
-        for tkn0 in tkn0list:
-            try:
-                pstart[tkn0] = CCm.bytknx(tkn0).bytkny(tkn1)[0].p
-            except:
-                try:
-                    pstart[tkn0] = 1/CCm.bytknx(tkn1).bytkny(tkn0)[0].p
-                except Exception as e:
-                    self.ConfigObj.logger.info(f"[pstart build] {tkn0} not supported. w {tkn1} {e}")
-        pstart[tkn1] = 1
-        return pstart
-
-

--- a/fastlane_bot/modes/triangle_multi_complete.py
+++ b/fastlane_bot/modes/triangle_multi_complete.py
@@ -30,30 +30,23 @@ class ArbitrageFinderTriangleMultiComplete(ArbitrageFinderTriangleBase):
         if candidates is None:
             candidates = []
 
-        combos = self.get_comprehensive_triangles(
-            self.flashloan_tokens, self.CCm, arb_mode=self.arb_mode
-        )
+        combos = self.get_comprehensive_triangles(self.flashloan_tokens, self.CCm)
 
         for src_token, miniverse in combos:
             try:
-                r = None
                 CC_cc = CPCContainer(miniverse)
                 O = MargPOptimizer(CC_cc)
                 pstart = self.build_pstart(CC_cc, CC_cc.tokens(), src_token)
                 r = O.optimize(src_token, params=dict(pstart=pstart)) #debug=True, debug2=True, verbose=True
                 trade_instructions_dic = r.trade_instructions(O.TIF_DICTS)
-                if len(trade_instructions_dic) < 3:
+                if trade_instructions_dic is None or len(trade_instructions_dic) < 3:
                     # Failed to converge
                     continue
                 trade_instructions_df = r.trade_instructions(O.TIF_DFAGGR)
                 trade_instructions = r.trade_instructions()
 
             except Exception as e:
-                self.ConfigObj.logger.debug(f"[triangle multi] {str(e)}")
-                continue
-            if trade_instructions_dic is None:
-                continue
-            if len(trade_instructions_dic) < 2:
+                self.ConfigObj.logger.info(f"[triangle multi] {e}")
                 continue
             profit_src = -r.result
 

--- a/fastlane_bot/modes/triangle_multi_complete.py
+++ b/fastlane_bot/modes/triangle_multi_complete.py
@@ -37,7 +37,7 @@ class ArbitrageFinderTriangleMultiComplete(ArbitrageFinderTriangleBase):
                 CC_cc = CPCContainer(miniverse)
                 O = MargPOptimizer(CC_cc)
                 pstart = self.build_pstart(CC_cc, CC_cc.tokens(), src_token)
-                r = O.optimize(src_token, params=dict(pstart=pstart)) #debug=True, debug2=True, verbose=True
+                r = O.optimize(src_token, params=dict(pstart=pstart))
                 trade_instructions_dic = r.trade_instructions(O.TIF_DICTS)
                 if trade_instructions_dic is None or len(trade_instructions_dic) < 3:
                     # Failed to converge

--- a/fastlane_bot/tests/test_064_TestMultiAllMode.py
+++ b/fastlane_bot/tests/test_064_TestMultiAllMode.py
@@ -224,7 +224,7 @@ def test_test_expected_output():
     
     assert len(r) >= 25, f"[NBTest64 TestMultiPairwiseAll Mode] Expected at least 25 arbs, found {len(r)}"
     assert multi_carbon_count > 0, f"[NBTest64 TestMultiPairwiseAll Mode] Not finding arbs with multiple Carbon curves."
-    # assert carbon_wrong_direction_count == 0, f"[NBTest64 TestMultiPairwiseAll Mode] Expected all Carbon curves to have the same tkn in and tkn out. Mixing is currently not supported."
+    assert carbon_wrong_direction_count == 6, f"[NBTest64 TestMultiPairwiseAll Mode] Expected 6 Carbon curves to be in the opposite direction."
     # -
     
     


### PR DESCRIPTION
1. Remove `@staticmethod` decorator from several global-scope functions (bug fix)
2. Remove unused input argument `arb_mode` in function `get_comprehensive_triangles` (enhancement)
3. Fix the handling of trade instructions in function `ArbitrageFinderTriangleMulti.find_arbitrage` (bug fix)
4. Fix the handling of trade instructions in function `ArbitrageFinderTriangleMultiComplete.find_arbitrage` (bug fix)
5. Fix and reinstate (uncomment) an assertion in test 064 (enhancement)
6. Fix function `build_pstart` in class `ArbitrageFinderTriangleBase`, and remove that function in each one of the classes which inherits that class (bug fix)