### PR TITLE
Unify code across the different arb-mode classes

### DIFF
--- a/fastlane_bot/modes/pairwise_multi_all.py
+++ b/fastlane_bot/modes/pairwise_multi_all.py
@@ -20,23 +20,23 @@ class ArbitrageFinderMultiPairwiseAll(ArbitrageFinderPairwiseBase):
         return [(tkn0, tkn1) for tkn0, tkn1 in product(all_tokens, flashloan_tokens_intersect) if tkn0 != tkn1]
 
     def get_curve_combos(self, CC: Any) -> List[Any]:
-        carbon_curves = [x for x in CC.curves if x.params.exchange in self.ConfigObj.CARBON_V1_FORKS]
-        non_carbon_curves = [x for x in CC.curves if x.params.exchange not in self.ConfigObj.CARBON_V1_FORKS]
-        curve_combos = [[_curve0] + [_curve1] for _curve0 in non_carbon_curves for _curve1 in non_carbon_curves if _curve0 != _curve1]
+        carbon_curves = [curve for curve in CC.curves if curve.params.exchange in self.ConfigObj.CARBON_V1_FORKS]
+        other_curves  = [curve for curve in CC.curves if curve.params.exchange not in self.ConfigObj.CARBON_V1_FORKS]
+        base_dir_one  = [curve for curve in CC.curves[:1] if curve.params.exchange in self.ConfigObj.CARBON_V1_FORKS]
+        base_dir_two  = [curve for curve in CC.curves[1:] if curve.params.exchange in self.ConfigObj.CARBON_V1_FORKS]
 
-        if len(carbon_curves) > 0:
-            base_direction_pair = carbon_curves[0].pair
-            base_direction_one = [curve for curve in carbon_curves if curve.pair == base_direction_pair]
-            base_direction_two = [curve for curve in carbon_curves if curve.pair != base_direction_pair]
-            curve_combos = []
+        curve_combos = []
 
-            if len(base_direction_one) > 0:
-                curve_combos += [[curve] + base_direction_one for curve in non_carbon_curves]
+        if len(base_dir_one) > 0:
+            curve_combos += [[curve] + base_dir_one for curve in other_curves]
 
-            if len(base_direction_two) > 0:
-                curve_combos += [[curve] + base_direction_two for curve in non_carbon_curves]
+        if len(base_dir_two) > 0:
+            curve_combos += [[curve] + base_dir_two for curve in other_curves]
 
-            if len(carbon_curves) >= 2:
-                curve_combos += [carbon_curves]
+        if len(carbon_curves) > 1:
+            curve_combos += [carbon_curves]
 
-        return curve_combos
+        if curve_combos:
+            return curve_combos
+    
+        return [[_curve0] + [_curve1] for _curve0 in other_curves for _curve1 in other_curves if _curve0 != _curve1]

--- a/fastlane_bot/modes/pairwise_multi_pol.py
+++ b/fastlane_bot/modes/pairwise_multi_pol.py
@@ -20,20 +20,15 @@ class ArbitrageFinderMultiPairwisePol(ArbitrageFinderPairwiseBase):
         return [(tkn0, tkn1) for tkn0, tkn1 in product(bancor_pol_tkns, [self.ConfigObj.WETH_ADDRESS]) if tkn0 != tkn1]
 
     def get_curve_combos(self, CC: Any) -> List[Any]:
-        pol_curves = [x for x in CC.curves if x.params.exchange == "bancor_pol"]
-        carbon_curves = [x for x in CC.curves if x.params.exchange in self.ConfigObj.CARBON_V1_FORKS]
-        non_carbon_curves = [x for x in CC.curves if x.params.exchange not in ["bancor_pol"] + self.ConfigObj.CARBON_V1_FORKS]
-        curve_combos = [[curve] + pol_curves for curve in non_carbon_curves]
+        pol_curves   = [curve for curve in CC.curves if curve.params.exchange == "bancor_pol"]
+        base_dir_one = [curve for curve in CC.curves[:1] if curve.params.exchange in self.ConfigObj.CARBON_V1_FORKS]
+        base_dir_two = [curve for curve in CC.curves[1:] if curve.params.exchange in self.ConfigObj.CARBON_V1_FORKS]
+        curve_combos = [[curve] + pol_curves for curve in CC.curves if curve.params.exchange not in ["bancor_pol"] + self.ConfigObj.CARBON_V1_FORKS]
 
-        if len(carbon_curves) > 0:
-            base_direction_pair = carbon_curves[0].pair
-            base_direction_one = [curve for curve in carbon_curves if curve.pair == base_direction_pair]
-            base_direction_two = [curve for curve in carbon_curves if curve.pair != base_direction_pair]
+        if len(base_dir_one) > 0:
+            curve_combos += [[curve] + base_dir_one for curve in pol_curves]
 
-            if len(base_direction_one) > 0:
-                curve_combos += [[curve] + base_direction_one for curve in pol_curves]
-
-            if len(base_direction_two) > 0:
-                curve_combos += [[curve] + base_direction_two for curve in pol_curves]
+        if len(base_dir_two) > 0:
+            curve_combos += [[curve] + base_dir_two for curve in pol_curves]
 
         return curve_combos

--- a/fastlane_bot/modes/triangle_multi.py
+++ b/fastlane_bot/modes/triangle_multi.py
@@ -16,45 +16,43 @@ from fastlane_bot.modes.base_triangle import ArbitrageFinderTriangleBase
 class ArbitrageFinderTriangleMulti(ArbitrageFinderTriangleBase):
     def get_combos(self) -> List[Any]:
         combos = []
-        all_base_exchange_curves = self.CCm.byparams(exchange="carbon_v1").curves
+        all_curves = list(set(self.CCm.byparams(exchange=exchange).curves for exchange in self.ConfigObj.CARBON_V1_FORKS))
 
-        for flt in self.flashloan_tokens:  # may wish to run this for one flt at a time
-            non_flt_base_exchange_curves = [x for x in all_base_exchange_curves if flt not in x.pair]
-            for non_flt_base_exchange_curve in non_flt_base_exchange_curves:
-                target_tkny = non_flt_base_exchange_curve.tkny
-                target_tknx = non_flt_base_exchange_curve.tknx
+        for flt in self.flashloan_tokens:
+            for non_flt_curve in [curve for curve in all_curves if flt not in curve.pair]:
+                tkny = non_flt_curve.tkny
+                tknx = non_flt_curve.tknx
 
-                base_exchange_curves = self.CCm.bypairs(f"{target_tknx}/{target_tkny}").byparams(exchange="carbon_v1").curves
-                if len(base_exchange_curves) == 0:
+                pair_curves = self.CCm.bypairs(f"{tknx}/{tkny}")
+                if len(pair_curves) == 0:
                     continue
 
-                base_direction_pair = base_exchange_curves[0].pair
-                base_direction_one = [curve for curve in base_exchange_curves if curve.pair == base_direction_pair]
-                base_direction_two = [curve for curve in base_exchange_curves if curve.pair != base_direction_pair]
+                base_dir_one = [curve for curve in pair_curves[:1] if curve.params.exchange in self.ConfigObj.CARBON_V1_FORKS]
+                base_dir_two = [curve for curve in pair_curves[1:] if curve.params.exchange in self.ConfigObj.CARBON_V1_FORKS]
 
-                y_match_curves = self.CCm.bypairs(set(self.CCm.filter_pairs(onein=target_tknx)) & set(self.CCm.filter_pairs(onein=flt)))
-                x_match_curves = self.CCm.bypairs(set(self.CCm.filter_pairs(onein=target_tkny)) & set(self.CCm.filter_pairs(onein=flt)))
+                y_match_curves = self.CCm.bypairs(set(self.CCm.filter_pairs(onein=tknx)) & set(self.CCm.filter_pairs(onein=flt)))
+                x_match_curves = self.CCm.bypairs(set(self.CCm.filter_pairs(onein=tkny)) & set(self.CCm.filter_pairs(onein=flt)))
 
-                y_match_curves_not_carbon = [x for x in y_match_curves if x.params.exchange != "carbon_v1"]
-                if len(y_match_curves_not_carbon) == 0:
+                y_match_other_curves = [curve for curve in y_match_curves if curve.params.exchange not in self.ConfigObj.CARBON_V1_FORKS]
+                if len(y_match_other_curves) == 0:
                     continue
 
-                x_match_curves_not_carbon = [x for x in x_match_curves if x.params.exchange != "carbon_v1"]
-                if len(x_match_curves_not_carbon) == 0:
+                x_match_other_curves = [curve for curve in x_match_curves if curve.params.exchange not in self.ConfigObj.CARBON_V1_FORKS]
+                if len(x_match_other_curves) == 0:
                     continue
 
-                if len(base_direction_one) > 0:
-                    combos += get_miniverse_combos(y_match_curves_not_carbon, base_direction_one, x_match_curves_not_carbon, flt)
+                if len(base_dir_one) > 0:
+                    combos += get_miniverse_combos(y_match_other_curves, x_match_other_curves, base_dir_one, flt)
 
-                if len(base_direction_two) > 0:
-                    combos += get_miniverse_combos(y_match_curves_not_carbon, base_direction_two, x_match_curves_not_carbon, flt)
+                if len(base_dir_two) > 0:
+                    combos += get_miniverse_combos(y_match_other_curves, x_match_other_curves, base_dir_two, flt)
 
         return combos
 
 def get_miniverse_combos(
-    y_match_curves_not_carbon: List[Any],
+    y_match_other_curves: List[Any],
+    x_match_other_curves: List[Any],
     base_exchange_curves: List[Any],
-    x_match_curves_not_carbon: List[Any],
     flt: str
 ):
     """
@@ -62,12 +60,12 @@ def get_miniverse_combos(
 
     Parameters
     ----------
-    y_match_curves_not_carbon : list
+    y_match_other_curves : list
         List of curves that match the y token and are not on carbon
+    x_match_other_curves : list
+        List of curves that match the x token and are not on carbon
     base_exchange_curves : list
         List of curves on the base exchange
-    x_match_curves_not_carbon : list
-        List of curves that match the x token and are not on carbon
     flt : str
         Flashloan token
 
@@ -75,6 +73,6 @@ def get_miniverse_combos(
     -------
     A list of miniverse combos
     """
-    curve_combos = list(product(y_match_curves_not_carbon, x_match_curves_not_carbon))
+    curve_combos = list(product(y_match_other_curves, x_match_other_curves))
     miniverses = [base_exchange_curves + list(combo) for combo in curve_combos]
     return [(flt, miniverse) for miniverse in miniverses]

--- a/fastlane_bot/modes/triangle_multi.py
+++ b/fastlane_bot/modes/triangle_multi.py
@@ -16,7 +16,7 @@ from fastlane_bot.modes.base_triangle import ArbitrageFinderTriangleBase
 class ArbitrageFinderTriangleMulti(ArbitrageFinderTriangleBase):
     def get_combos(self) -> List[Any]:
         combos = []
-        all_curves = list(set(self.CCm.byparams(exchange=exchange).curves for exchange in self.ConfigObj.CARBON_V1_FORKS))
+        all_curves = [self.CCm.byparams(exchange=exchange).curves for exchange in self.ConfigObj.CARBON_V1_FORKS]
 
         for flt in self.flashloan_tokens:
             for non_flt_curve in [curve for curve in all_curves if flt not in curve.pair]:

--- a/fastlane_bot/modes/triangle_multi_complete.py
+++ b/fastlane_bot/modes/triangle_multi_complete.py
@@ -83,29 +83,17 @@ def get_all_relevant_pairs_info(CCm, all_relevant_pairs, carbon_v1_forks):
     for pair in all_relevant_pairs:            
         all_relevant_pairs_info[pair] = {}
         pair_curves = CCm.bypair(pair)
-        carbon_curves = []
-        non_carbon_curves = []
-        base_direction_one = []
-        base_direction_two = []
-        if len(pair_curves) > 0:
-            base_direction_pair = pair_curves[0].pair
-            for x in pair_curves:
-                if x.params.exchange in carbon_v1_forks:
-                    carbon_curves += [x]
-                    if x.pair == base_direction_pair:
-                        base_direction_one += [x]
-                    else:
-                        base_direction_two += [x]
-                else:
-                    non_carbon_curves += [x]
-        all_relevant_pairs_info[pair]['curves'] = non_carbon_curves
-        # for each direction, condense carbon curves into a single list and add to the non-carbon curves
-        if len(base_direction_one) > 0:
-            all_relevant_pairs_info[pair]['curves'].append(base_direction_one)
-        if len(base_direction_two) > 0:
-            all_relevant_pairs_info[pair]['curves'].append(base_direction_two)
-        all_relevant_pairs_info[pair]['all_counts'] = len(pair_curves)
-        all_relevant_pairs_info[pair]['carbon_counts'] = len(carbon_curves)
+        carbon_curves = [curve for curve in pair_curves if curve.params.exchange in carbon_v1_forks]
+        other_curves  = [curve for curve in pair_curves if curve.params.exchange not in carbon_v1_forks]
+        base_dir_one  = [curve for curve in pair_curves[:1] if curve.params.exchange in carbon_v1_forks]
+        base_dir_two  = [curve for curve in pair_curves[1:] if curve.params.exchange in carbon_v1_forks]
+        all_relevant_pairs_info[pair]['curves'] = other_curves
+        if len(base_dir_one) > 0:
+            all_relevant_pairs_info[pair]['curves'].append(base_dir_one)
+        if len(base_dir_two) > 0:
+            all_relevant_pairs_info[pair]['curves'].append(base_dir_two)
+        all_relevant_pairs_info[pair]['total_count'] = len(pair_curves)
+        all_relevant_pairs_info[pair]['carbon_count'] = len(carbon_curves)
     return all_relevant_pairs_info
 
 def get_triangle_groups_stats(triangle_groups, all_relevant_pairs_info):
@@ -115,9 +103,9 @@ def get_triangle_groups_stats(triangle_groups, all_relevant_pairs_info):
         path_len = 0
         has_carbon = False
         for pair in triangle:
-            if all_relevant_pairs_info[pair]['all_counts'] > 0:
+            if all_relevant_pairs_info[pair]['total_count'] > 0:
                 path_len += 1
-            if all_relevant_pairs_info[pair]['carbon_counts'] > 0:
+            if all_relevant_pairs_info[pair]['carbon_count'] > 0:
                 has_carbon = True
         if path_len == 3 and has_carbon == True:
             valid_carbon_triangles.append(triangle)


### PR DESCRIPTION
1. Unify code across the different arb-mode classes
2. Extend the triangle-multi mode to support all carbon forks